### PR TITLE
record all keycloak events

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,18 @@ Two distinct providers are defined:
 The endpoint lives under `<url>/auth/realms/<realm>/metrics`. It will return data for all realms, no matter which realm
 you use in the URL (you can just default to `/auth/realms/master/metrics`).
 
+## Running the tests
+
+```sh
+$ ./gradlew test
+```
+
 ## Build
 
 The project is packages as a jar file and bundles the prometheus client libraries.
 
 ```sh
-$ gradle jar
+$ ./gradlew jar
 ```
 
 builds the jar and writes it to _build/libs_.
@@ -23,3 +29,7 @@ builds the jar and writes it to _build/libs_.
 ## Usage
 
 Just drop the jar into the _providers_ subdirectory of your KeyCloak installation. To enbale the event listener go to _Manage -> Events -> Config_. The _Event Listeners_ configuration should have an entry named `metrics-listener`.
+
+## Metrics
+
+The endpoint will return JVM performance metrics, counters of all KeyCloak events and the number of logged in users (_kc_logged_in_users_).

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Jan 18 11:31:25 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpoint.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpoint.java
@@ -20,7 +20,7 @@ public class MetricsEndpoint implements RealmResourceProvider {
   @GET
   @Produces(MediaType.TEXT_PLAIN)
   public Response get() {
-    StreamingOutput stream = output -> PrometheusExporter.instance().export(output);
+    final StreamingOutput stream = output -> PrometheusExporter.instance().export(output);
     return Response.ok(stream).build();
   }
 

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListener.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListener.java
@@ -18,16 +18,21 @@ public class MetricsEventListener implements EventListenerProvider {
     switch (event.getType()) {
       case LOGIN:
       case IMPERSONATE:
+        // Login and Impersonate both increase the number of currently
+        // logged in users
         PrometheusExporter.instance().recordUserLogin(event);
+        PrometheusExporter.instance().recordUserEvent(event);
         break;
-      case LOGIN_ERROR:
-      case IMPERSONATE_ERROR:
-        PrometheusExporter.instance().recordFailedLogin(event);
       case LOGOUT:
+        // Logout is the only action that decreases the number of currently
+        // logged in users
         PrometheusExporter.instance().recordUserLogout(event);
+        PrometheusExporter.instance().recordUserEvent(event);
+        break;
       default:
-        // Ignore other event types for now
-        return;
+        // Default action: record all other events in a generic way
+        PrometheusExporter.instance().recordUserEvent(event);
+        break;
     }
   }
 
@@ -37,6 +42,8 @@ public class MetricsEventListener implements EventListenerProvider {
       event.getOperationType().name(),
       event.getResourceType().name(),
       event.getRealmId());
+
+    PrometheusExporter.instance().recordAdminEvent(event);
   }
 
   @Override

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -1,0 +1,58 @@
+package org.jboss.aerogear.keycloak.metrics;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventType;
+import org.keycloak.events.admin.OperationType;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class PrometheusExporterTest {
+  private Event createEvent(EventType type) {
+    final Event event = new Event();
+    event.setType(type);
+    event.setRealmId("myrealm");
+    return event;
+  }
+
+  @Test
+  public void shouldRegisterAllKeycloakEvents() {
+    int userEvents = EventType.values().length;
+    int adminEvents = OperationType.values().length;
+
+    MatcherAssert.assertThat(
+      "All events registered",
+      userEvents + adminEvents == PrometheusExporter.counters.size());
+  }
+
+  @Test
+  public void shouldCorrectlyCountLogin() throws IOException {
+    final Event login = createEvent(EventType.LOGIN);
+    PrometheusExporter.instance().recordUserLogin(login);
+    assertLoggedInCount(1);
+    final Event logout = createEvent(EventType.LOGOUT);
+    PrometheusExporter.instance().recordUserLogout(logout);
+    assertLoggedInCount(0);
+  }
+
+  @Test
+  public void shouldCorrectlyCountImpersonate() throws IOException {
+    final Event imporsonate = createEvent(EventType.IMPERSONATE);
+    PrometheusExporter.instance().recordUserLogin(imporsonate);
+    assertLoggedInCount(1);
+    final Event logout = createEvent(EventType.LOGOUT);
+    PrometheusExporter.instance().recordUserLogout(logout);
+    assertLoggedInCount(0);
+  }
+
+  private void assertLoggedInCount(double number) throws IOException {
+    try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
+      PrometheusExporter.instance().export(stream);
+      String result = new String(stream.toByteArray());
+      MatcherAssert.assertThat("Logout count",
+        result.contains("kc_logged_in_users{realm=\"myrealm\",} " + number));
+    }
+  }
+}


### PR DESCRIPTION
Record all KeyCloak events (plus logged in users and performance metrics). Previously only logged in users and failed login attempts were counted. Now a counter for every user and admin event is saved.

Also added a test.