### PR TITLE
Latest prometheus and removing unneeded declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,8 @@ dependencies {
     compile group: 'org.keycloak', name: 'keycloak-server-spi', version: '3.2.1.Final'
     compile group: 'org.keycloak', name: 'keycloak-services', version: '3.2.1.Final'
     compile group: 'org.jboss.spec.javax.ws.rs', name: 'jboss-jaxrs-api_2.0_spec', version: '1.0.0.Final'
-    bundleLib group: 'io.prometheus', name: 'simpleclient', version: '0.1.0'
-    bundleLib group: 'io.prometheus', name: 'simpleclient_common', version: '0.1.0'
-    bundleLib group: 'io.prometheus', name: 'simpleclient_hotspot', version: '0.1.0'
+    bundleLib group: 'io.prometheus', name: 'simpleclient_common', version: '0.2.0'
+    bundleLib group: 'io.prometheus', name: 'simpleclient_hotspot', version: '0.2.0'
     configurations.compile.extendsFrom(configurations.bundleLib)
 
     testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
New lib was released

As well, clean up on the used dependencies, the `simpleclient` is a direct dependency by the `_common` JAR file, see:

https://github.com/prometheus/client_java/blob/parent-0.2.0/simpleclient_common/pom.xml#L38-L40 