### PR TITLE
Fixes nullpointer exception by changin `break` for `continue`

### DIFF
--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -45,7 +45,7 @@ public final class PrometheusExporter {
         // Counters for all user events
         for (EventType type : EventType.values()) {
             if (type.equals(EventType.LOGIN) || type.equals(EventType.LOGIN_ERROR) || type.equals(EventType.REGISTER)) {
-                break;
+                continue;
             }
             final String eventName = USER_EVENT_PREFIX + type.name();
             counters.put(eventName, createCounter(eventName, false));


### PR DESCRIPTION
Wrong keyword was being used in the loop, so that necessary counters weren't being created ending up in a nullpointer exception each time a counter was to be incremented.