### PR TITLE
AEROGEAR-2096 mobile metrics tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# File for usage with http://editorconfig.org/ editor plugins
+# For more details on code style and editor-specific configuration files, see https://github.com/aerogear/ide-config
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+# The following property is not yet available via EditorConfig, but part of our style guideline
+# see https://github.com/editorconfig/editorconfig/wiki/Property-research:-maximum-line-length
+# max_line_length: 128
+
+[*.{java,gradle}]
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ builds the jar and writes it to _build/libs_.
 
 ## Usage
 
-Just drop the jar into the _providers_ subdirectory of your KeyCloak installation. To enbale the event listener go to _Manage -> Events -> Config_. The _Event Listeners_ configuration should have an entry named `metrics-listener`.
+Just drop the jar into the _providers_ subdirectory of your KeyCloak installation. To enable the event listener go to _Manage -> Events -> Config_. The _Event Listeners_ configuration should have an entry named `metrics-listener`.
 
 ## Metrics
 

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListener.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListener.java
@@ -17,7 +17,6 @@ public class MetricsEventListener implements EventListenerProvider {
 
         switch (event.getType()) {
             case LOGIN:
-            case IMPERSONATE:
                 PrometheusExporter.instance().recordLogin(event);
                 break;
             case REGISTER:

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -116,7 +116,7 @@ public final class PrometheusExporter {
     /**
      * Increase the number of currently logged in users
      *
-     * @param event Login or Impersonate event
+     * @param event Login event
      */
     public void recordLogin(final Event event) {
         final String provider = event.getDetails()

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -2,7 +2,6 @@ package org.jboss.aerogear.keycloak.metrics;
 
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
 import io.prometheus.client.exporter.common.TextFormat;
 import io.prometheus.client.hotspot.DefaultExports;
 import org.keycloak.events.Event;
@@ -18,24 +17,29 @@ public final class PrometheusExporter {
 
     private final static String USER_EVENT_PREFIX = "keycloak_user_event_";
     private final static String ADMIN_EVENT_PREFIX = "keycloak_admin_event_";
-    private static final String PROVIDER_KEYCLOAK_OPENID = "keycloak";
+    private final static String PROVIDER_KEYCLOAK_OPENID = "keycloak";
     private final static PrometheusExporter INSTANCE = new PrometheusExporter();
     private final static CollectorRegistry registry = CollectorRegistry.defaultRegistry;
-    private final static Map<String, Counter> counters = new HashMap<>();
 
-    private final static Counter totalLogins = Counter.build()
+    // package private by on purpose
+    final static Map<String, Counter> counters = new HashMap<>();
+
+    // package private by on purpose
+    final static Counter totalLogins = Counter.build()
             .name("keycloak_logins")
             .help("Total successful logins")
             .labelNames("realm", "provider")
             .register();
 
-    private final static Counter totalFailedLoginAttempts = Counter.build()
+    // package private by on purpose
+    final static Counter totalFailedLoginAttempts = Counter.build()
             .name("keycloak_failed_login_attempts")
             .help("Total failed login attempts")
             .labelNames("realm", "provider", "error")
             .register();
 
-    private final static Counter totalRegistrations = Counter.build()
+    // package private by on purpose
+    final static Counter totalRegistrations = Counter.build()
             .name("keycloak_registrations")
             .help("Total registered users")
             .labelNames("realm", "provider")

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -21,16 +21,10 @@ public final class PrometheusExporter {
 
     private final static PrometheusExporter INSTANCE = new PrometheusExporter();
 
-    // package private by on purpose
+    // these fields are package private by on purpose
     final Map<String, Counter> counters = new HashMap<>();
-
-    // package private by on purpose
     final Counter totalLogins;
-
-    // package private by on purpose
     final Counter totalFailedLoginAttempts;
-
-    // package private by on purpose
     final Counter totalRegistrations;
 
     private PrometheusExporter() {

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -68,7 +68,7 @@ public class PrometheusExporterTest {
     }
 
     @Test
-    public void shouldCorrectlyCountLogin() throws IOException {
+    public void shouldCorrectlyCountLoginsFromDifferentProviders() throws IOException {
         // with id provider defined
         final Event login1 = createEvent(EventType.LOGIN, tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordLogin(login1);

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -1,6 +1,8 @@
 package org.jboss.aerogear.keycloak.metrics;
 
+import io.prometheus.client.Counter;
 import org.hamcrest.MatcherAssert;
+import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.events.Event;
 import org.keycloak.events.EventType;
@@ -8,13 +10,23 @@ import org.keycloak.events.admin.OperationType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 
 public class PrometheusExporterTest {
-  private Event createEvent(EventType type) {
-    final Event event = new Event();
-    event.setType(type);
-    event.setRealmId("myrealm");
-    return event;
+
+  @Before
+  public void before(){
+    for (Counter counter : PrometheusExporter.instance().counters.values()) {
+      counter.clear();
+    }
+    PrometheusExporter.instance().totalLogins.clear();
+    PrometheusExporter.instance().totalFailedLoginAttempts.clear();
+    PrometheusExporter.instance().totalRegistrations.clear();
   }
 
   @Test
@@ -23,36 +35,85 @@ public class PrometheusExporterTest {
     int adminEvents = OperationType.values().length;
 
     MatcherAssert.assertThat(
-      "All events registered",
-      userEvents + adminEvents == PrometheusExporter.counters.size());
+            "All events registered",
+            userEvents + adminEvents - 3,                             // -3 comes from the events that
+            is(PrometheusExporter.instance().counters.size()));       // have their own counters outside the counter map
+
+  }
+
+  @Test
+  public void shouldCorrectlyCountLoginWhenIdentityProviderIsDefined() throws IOException {
+    final Map<String, String> details1 = new HashMap<>();
+    details1.put("identity_provider", "THE_ID_PROVIDER");
+    final Event login1 = createEvent(EventType.LOGIN, details1);
+    PrometheusExporter.instance().recordLogin(login1);
+    assertLoggedInCount(1, "THE_ID_PROVIDER");
+
+    final Map<String, String> details2 = new HashMap<>();
+    details2.put("identity_provider", "THE_ID_PROVIDER");
+    final Event login2 = createEvent(EventType.LOGIN, details2);
+    PrometheusExporter.instance().recordLogin(login2);
+    assertLoggedInCount(2, "THE_ID_PROVIDER");
+  }
+
+  @Test
+  public void shouldCorrectlyCountLoginWhenIdentityProviderIsNotDefined() throws IOException {
+    final Event login1 = createEvent(EventType.LOGIN);
+    PrometheusExporter.instance().recordLogin(login1);
+    assertLoggedInCount(1, "keycloak");
+
+    final Event login2 = createEvent(EventType.LOGIN);
+    PrometheusExporter.instance().recordLogin(login2);
+    assertLoggedInCount(2, "keycloak");
   }
 
   @Test
   public void shouldCorrectlyCountLogin() throws IOException {
-    final Event login = createEvent(EventType.LOGIN);
-    PrometheusExporter.instance().recordUserLogin(login);
-    assertLoggedInCount(1);
-    final Event logout = createEvent(EventType.LOGOUT);
-    PrometheusExporter.instance().recordUserLogout(logout);
-    assertLoggedInCount(0);
+    // with id provider defined
+    final Map<String, String> details1 = new HashMap<>();
+    details1.put("identity_provider", "THE_ID_PROVIDER");
+    final Event login1 = createEvent(EventType.LOGIN, details1);
+    PrometheusExporter.instance().recordLogin(login1);
+    assertLoggedInCount(1, "THE_ID_PROVIDER");
+
+    // without id provider defined
+    final Event login2 = createEvent(EventType.LOGIN);
+    PrometheusExporter.instance().recordLogin(login2);
+    assertLoggedInCount(1, "keycloak");
+    assertLoggedInCount(1, "THE_ID_PROVIDER");
   }
 
-  @Test
-  public void shouldCorrectlyCountImpersonate() throws IOException {
-    final Event imporsonate = createEvent(EventType.IMPERSONATE);
-    PrometheusExporter.instance().recordUserLogin(imporsonate);
-    assertLoggedInCount(1);
-    final Event logout = createEvent(EventType.LOGOUT);
-    PrometheusExporter.instance().recordUserLogout(logout);
-    assertLoggedInCount(0);
-  }
+//  @Test
+//  public void shouldCorrectlyCountImpersonate() throws IOException {
+//    final Event imporsonate1 = createEvent(EventType.IMPERSONATE);
+//    PrometheusExporter.instance().recordLogin(imporsonate1);
+//    assertLoggedInCount(1, "keycloak");
+//    final Event imporsonate2 = createEvent(EventType.IMPERSONATE);
+//    PrometheusExporter.instance().recordLogin(imporsonate2);
+//    assertLoggedInCount(2, "keycloak");
+//  }
 
-  private void assertLoggedInCount(double number) throws IOException {
+  private void assertLoggedInCount(double number, String provider) throws IOException {
     try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
       PrometheusExporter.instance().export(stream);
       String result = new String(stream.toByteArray());
-      MatcherAssert.assertThat("Logout count",
-        result.contains("kc_logged_in_users{realm=\"myrealm\",} " + number));
+      MatcherAssert.assertThat(result, containsString("keycloak_logins{realm=\"myrealm\",provider=\"" + provider + "\",} " + number));
     }
+  }
+
+  private Event createEvent(EventType type, Map<String, String> details) {
+    final Event event = new Event();
+    event.setType(type);
+    event.setRealmId("myrealm");
+    if (details != null) {
+      event.setDetails(details);
+    } else {
+      event.setDetails(Collections.emptyMap());
+    }
+    return event;
+  }
+
+  private Event createEvent(EventType type) {
+    return createEvent(type, null);
   }
 }

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -47,24 +47,24 @@ public class PrometheusExporterTest {
         details1.put("identity_provider", "THE_ID_PROVIDER");
         final Event login1 = createEvent(EventType.LOGIN, details1);
         PrometheusExporter.instance().recordLogin(login1);
-        assertLoggedInCount(1, "THE_ID_PROVIDER");
+        assertMetric("keycloak_logins", "THE_ID_PROVIDER", 1);
 
         final Map<String, String> details2 = new HashMap<>();
         details2.put("identity_provider", "THE_ID_PROVIDER");
         final Event login2 = createEvent(EventType.LOGIN, details2);
         PrometheusExporter.instance().recordLogin(login2);
-        assertLoggedInCount(2, "THE_ID_PROVIDER");
+        assertMetric("keycloak_logins", "THE_ID_PROVIDER", 2);
     }
 
     @Test
     public void shouldCorrectlyCountLoginWhenIdentityProviderIsNotDefined() throws IOException {
         final Event login1 = createEvent(EventType.LOGIN);
         PrometheusExporter.instance().recordLogin(login1);
-        assertLoggedInCount(1, "keycloak");
+        assertMetric("keycloak_logins", "keycloak", 1);
 
         final Event login2 = createEvent(EventType.LOGIN);
         PrometheusExporter.instance().recordLogin(login2);
-        assertLoggedInCount(2, "keycloak");
+        assertMetric("keycloak_logins", "keycloak", 2);
     }
 
     @Test
@@ -74,20 +74,54 @@ public class PrometheusExporterTest {
         details1.put("identity_provider", "THE_ID_PROVIDER");
         final Event login1 = createEvent(EventType.LOGIN, details1);
         PrometheusExporter.instance().recordLogin(login1);
-        assertLoggedInCount(1, "THE_ID_PROVIDER");
+        assertMetric("keycloak_logins", "THE_ID_PROVIDER", 1);
 
         // without id provider defined
         final Event login2 = createEvent(EventType.LOGIN);
         PrometheusExporter.instance().recordLogin(login2);
-        assertLoggedInCount(1, "keycloak");
-        assertLoggedInCount(1, "THE_ID_PROVIDER");
+        assertMetric("keycloak_logins", "keycloak", 1);
+        assertMetric("keycloak_logins", "THE_ID_PROVIDER", 1);
     }
 
-    private void assertLoggedInCount(double number, String provider) throws IOException {
+//    @Test
+//    public void shouldCorrectlyCountLoginError() throws IOException {
+//        // with id provider defined
+//        final Map<String, String> details1 = new HashMap<>();
+//        details1.put("identity_provider", "THE_ID_PROVIDER");
+//        final Event event1 = createEvent(EventType.LOGIN_ERROR, details1);
+//        event1.setError("user_not_found");
+//        PrometheusExporter.instance().recordLoginError(event1);
+//        assertMetric("keycloak_failed_login_attempts", "THE_ID_PROVIDER", 1);
+//
+//        // without id provider defined
+//        final Event event2 = createEvent(EventType.LOGIN_ERROR);
+//        PrometheusExporter.instance().recordLoginError(event2);
+//        event2.setError("user_not_found");
+//        assertMetric("keycloak_failed_login_attempts", "keycloak", 1);
+//        assertMetric("keycloak_failed_login_attempts", "THE_ID_PROVIDER", 1);
+//    }
+
+    @Test
+    public void shouldCorrectlyCountRegister() throws IOException {
+        // with id provider defined
+        final Map<String, String> details1 = new HashMap<>();
+        details1.put("identity_provider", "THE_ID_PROVIDER");
+        final Event event1 = createEvent(EventType.REGISTER, details1);
+        PrometheusExporter.instance().recordRegistration(event1);
+        assertMetric("keycloak_registrations", "THE_ID_PROVIDER", 1);
+
+        // without id provider defined
+        final Event event2 = createEvent(EventType.REGISTER);
+        PrometheusExporter.instance().recordRegistration(event2);
+        assertMetric("keycloak_registrations", "keycloak", 1);
+        assertMetric("keycloak_registrations", "THE_ID_PROVIDER", 1);
+    }
+
+    private void assertMetric(String metricName, String provider, double metricValue) throws IOException {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
             PrometheusExporter.instance().export(stream);
             String result = new String(stream.toByteArray());
-            MatcherAssert.assertThat(result, containsString("keycloak_logins{realm=\"myrealm\",provider=\"" + provider + "\",} " + number));
+            MatcherAssert.assertThat(result, containsString(metricName + "{realm=\"myrealm\",provider=\"" + provider + "\",} " + metricValue));
         }
     }
 

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -19,69 +19,69 @@ import static org.hamcrest.CoreMatchers.is;
 
 public class PrometheusExporterTest {
 
-  @Before
-  public void before(){
-    for (Counter counter : PrometheusExporter.instance().counters.values()) {
-      counter.clear();
+    @Before
+    public void before() {
+        for (Counter counter : PrometheusExporter.instance().counters.values()) {
+            counter.clear();
+        }
+        PrometheusExporter.instance().totalLogins.clear();
+        PrometheusExporter.instance().totalFailedLoginAttempts.clear();
+        PrometheusExporter.instance().totalRegistrations.clear();
     }
-    PrometheusExporter.instance().totalLogins.clear();
-    PrometheusExporter.instance().totalFailedLoginAttempts.clear();
-    PrometheusExporter.instance().totalRegistrations.clear();
-  }
 
-  @Test
-  public void shouldRegisterAllKeycloakEvents() {
-    int userEvents = EventType.values().length;
-    int adminEvents = OperationType.values().length;
+    @Test
+    public void shouldRegisterAllKeycloakEvents() {
+        int userEvents = EventType.values().length;
+        int adminEvents = OperationType.values().length;
 
-    MatcherAssert.assertThat(
-            "All events registered",
-            userEvents + adminEvents - 3,                             // -3 comes from the events that
-            is(PrometheusExporter.instance().counters.size()));       // have their own counters outside the counter map
+        MatcherAssert.assertThat(
+                "All events registered",
+                userEvents + adminEvents - 3,                             // -3 comes from the events that
+                is(PrometheusExporter.instance().counters.size()));       // have their own counters outside the counter map
 
-  }
+    }
 
-  @Test
-  public void shouldCorrectlyCountLoginWhenIdentityProviderIsDefined() throws IOException {
-    final Map<String, String> details1 = new HashMap<>();
-    details1.put("identity_provider", "THE_ID_PROVIDER");
-    final Event login1 = createEvent(EventType.LOGIN, details1);
-    PrometheusExporter.instance().recordLogin(login1);
-    assertLoggedInCount(1, "THE_ID_PROVIDER");
+    @Test
+    public void shouldCorrectlyCountLoginWhenIdentityProviderIsDefined() throws IOException {
+        final Map<String, String> details1 = new HashMap<>();
+        details1.put("identity_provider", "THE_ID_PROVIDER");
+        final Event login1 = createEvent(EventType.LOGIN, details1);
+        PrometheusExporter.instance().recordLogin(login1);
+        assertLoggedInCount(1, "THE_ID_PROVIDER");
 
-    final Map<String, String> details2 = new HashMap<>();
-    details2.put("identity_provider", "THE_ID_PROVIDER");
-    final Event login2 = createEvent(EventType.LOGIN, details2);
-    PrometheusExporter.instance().recordLogin(login2);
-    assertLoggedInCount(2, "THE_ID_PROVIDER");
-  }
+        final Map<String, String> details2 = new HashMap<>();
+        details2.put("identity_provider", "THE_ID_PROVIDER");
+        final Event login2 = createEvent(EventType.LOGIN, details2);
+        PrometheusExporter.instance().recordLogin(login2);
+        assertLoggedInCount(2, "THE_ID_PROVIDER");
+    }
 
-  @Test
-  public void shouldCorrectlyCountLoginWhenIdentityProviderIsNotDefined() throws IOException {
-    final Event login1 = createEvent(EventType.LOGIN);
-    PrometheusExporter.instance().recordLogin(login1);
-    assertLoggedInCount(1, "keycloak");
+    @Test
+    public void shouldCorrectlyCountLoginWhenIdentityProviderIsNotDefined() throws IOException {
+        final Event login1 = createEvent(EventType.LOGIN);
+        PrometheusExporter.instance().recordLogin(login1);
+        assertLoggedInCount(1, "keycloak");
 
-    final Event login2 = createEvent(EventType.LOGIN);
-    PrometheusExporter.instance().recordLogin(login2);
-    assertLoggedInCount(2, "keycloak");
-  }
+        final Event login2 = createEvent(EventType.LOGIN);
+        PrometheusExporter.instance().recordLogin(login2);
+        assertLoggedInCount(2, "keycloak");
+    }
 
-  @Test
-  public void shouldCorrectlyCountLogin() throws IOException {
-    // with id provider defined
-    final Map<String, String> details1 = new HashMap<>();
-    details1.put("identity_provider", "THE_ID_PROVIDER");
-    final Event login1 = createEvent(EventType.LOGIN, details1);
-    PrometheusExporter.instance().recordLogin(login1);
-    assertLoggedInCount(1, "THE_ID_PROVIDER");
+    @Test
+    public void shouldCorrectlyCountLogin() throws IOException {
+        // with id provider defined
+        final Map<String, String> details1 = new HashMap<>();
+        details1.put("identity_provider", "THE_ID_PROVIDER");
+        final Event login1 = createEvent(EventType.LOGIN, details1);
+        PrometheusExporter.instance().recordLogin(login1);
+        assertLoggedInCount(1, "THE_ID_PROVIDER");
 
-    // without id provider defined
-    final Event login2 = createEvent(EventType.LOGIN);
-    PrometheusExporter.instance().recordLogin(login2);
-    assertLoggedInCount(1, "keycloak");
-    assertLoggedInCount(1, "THE_ID_PROVIDER");
-  }
+        // without id provider defined
+        final Event login2 = createEvent(EventType.LOGIN);
+        PrometheusExporter.instance().recordLogin(login2);
+        assertLoggedInCount(1, "keycloak");
+        assertLoggedInCount(1, "THE_ID_PROVIDER");
+    }
 
 //  @Test
 //  public void shouldCorrectlyCountImpersonate() throws IOException {
@@ -93,27 +93,27 @@ public class PrometheusExporterTest {
 //    assertLoggedInCount(2, "keycloak");
 //  }
 
-  private void assertLoggedInCount(double number, String provider) throws IOException {
-    try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
-      PrometheusExporter.instance().export(stream);
-      String result = new String(stream.toByteArray());
-      MatcherAssert.assertThat(result, containsString("keycloak_logins{realm=\"myrealm\",provider=\"" + provider + "\",} " + number));
+    private void assertLoggedInCount(double number, String provider) throws IOException {
+        try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
+            PrometheusExporter.instance().export(stream);
+            String result = new String(stream.toByteArray());
+            MatcherAssert.assertThat(result, containsString("keycloak_logins{realm=\"myrealm\",provider=\"" + provider + "\",} " + number));
+        }
     }
-  }
 
-  private Event createEvent(EventType type, Map<String, String> details) {
-    final Event event = new Event();
-    event.setType(type);
-    event.setRealmId("myrealm");
-    if (details != null) {
-      event.setDetails(details);
-    } else {
-      event.setDetails(Collections.emptyMap());
+    private Event createEvent(EventType type, Map<String, String> details) {
+        final Event event = new Event();
+        event.setType(type);
+        event.setRealmId("myrealm");
+        if (details != null) {
+            event.setDetails(details);
+        } else {
+            event.setDetails(Collections.emptyMap());
+        }
+        return event;
     }
-    return event;
-  }
 
-  private Event createEvent(EventType type) {
-    return createEvent(type, null);
-  }
+    private Event createEvent(EventType type) {
+        return createEvent(type, null);
+    }
 }

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -83,16 +83,6 @@ public class PrometheusExporterTest {
         assertLoggedInCount(1, "THE_ID_PROVIDER");
     }
 
-//  @Test
-//  public void shouldCorrectlyCountImpersonate() throws IOException {
-//    final Event imporsonate1 = createEvent(EventType.IMPERSONATE);
-//    PrometheusExporter.instance().recordLogin(imporsonate1);
-//    assertLoggedInCount(1, "keycloak");
-//    final Event imporsonate2 = createEvent(EventType.IMPERSONATE);
-//    PrometheusExporter.instance().recordLogin(imporsonate2);
-//    assertLoggedInCount(2, "keycloak");
-//  }
-
     private void assertLoggedInCount(double number, String provider) throws IOException {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
             PrometheusExporter.instance().export(stream);

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -34,7 +34,7 @@ public class PrometheusExporterTest {
     }
 
     @Test
-    public void shouldRegisterAllKeycloakEvents() {
+    public void shouldRegisterCountersForAllKeycloakEvents() {
         int userEvents = EventType.values().length;
         int adminEvents = OperationType.values().length;
 
@@ -47,66 +47,66 @@ public class PrometheusExporterTest {
 
     @Test
     public void shouldCorrectlyCountLoginWhenIdentityProviderIsDefined() throws IOException {
-        final Event login1 = createEvent(EventType.LOGIN, Tuple.of("identity_provider", "THE_ID_PROVIDER"));
+        final Event login1 = createEvent(EventType.LOGIN, tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordLogin(login1);
-        assertMetric("keycloak_logins", 1, Tuple.of("provider", "THE_ID_PROVIDER"));
+        assertMetric("keycloak_logins", 1, tuple("provider", "THE_ID_PROVIDER"));
 
-        final Event login2 = createEvent(EventType.LOGIN, Tuple.of("identity_provider", "THE_ID_PROVIDER"));
+        final Event login2 = createEvent(EventType.LOGIN, tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordLogin(login2);
-        assertMetric("keycloak_logins", 2, Tuple.of("provider", "THE_ID_PROVIDER"));
+        assertMetric("keycloak_logins", 2, tuple("provider", "THE_ID_PROVIDER"));
     }
 
     @Test
     public void shouldCorrectlyCountLoginWhenIdentityProviderIsNotDefined() throws IOException {
         final Event login1 = createEvent(EventType.LOGIN);
         PrometheusExporter.instance().recordLogin(login1);
-        assertMetric("keycloak_logins", 1, Tuple.of("provider", "keycloak"));
+        assertMetric("keycloak_logins", 1, tuple("provider", "keycloak"));
 
         final Event login2 = createEvent(EventType.LOGIN);
         PrometheusExporter.instance().recordLogin(login2);
-        assertMetric("keycloak_logins", 2, Tuple.of("provider", "keycloak"));
+        assertMetric("keycloak_logins", 2, tuple("provider", "keycloak"));
     }
 
     @Test
     public void shouldCorrectlyCountLogin() throws IOException {
         // with id provider defined
-        final Event login1 = createEvent(EventType.LOGIN, Tuple.of("identity_provider", "THE_ID_PROVIDER"));
+        final Event login1 = createEvent(EventType.LOGIN, tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordLogin(login1);
-        assertMetric("keycloak_logins", 1, Tuple.of("provider", "THE_ID_PROVIDER"));
+        assertMetric("keycloak_logins", 1, tuple("provider", "THE_ID_PROVIDER"));
 
         // without id provider defined
         final Event login2 = createEvent(EventType.LOGIN);
         PrometheusExporter.instance().recordLogin(login2);
-        assertMetric("keycloak_logins", 1, Tuple.of("provider", "keycloak"));
-        assertMetric("keycloak_logins", 1, Tuple.of("provider", "THE_ID_PROVIDER"));
+        assertMetric("keycloak_logins", 1, tuple("provider", "keycloak"));
+        assertMetric("keycloak_logins", 1, tuple("provider", "THE_ID_PROVIDER"));
     }
 
     @Test
     public void shouldCorrectlyCountLoginError() throws IOException {
         // with id provider defined
-        final Event event1 = createEvent(EventType.LOGIN_ERROR, "user_not_found", Tuple.of("identity_provider", "THE_ID_PROVIDER"));
+        final Event event1 = createEvent(EventType.LOGIN_ERROR, "user_not_found", tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordLoginError(event1);
-        assertMetric("keycloak_failed_login_attempts", 1, Tuple.of("provider", "THE_ID_PROVIDER"), Tuple.of("error", "user_not_found"));
+        assertMetric("keycloak_failed_login_attempts", 1, tuple("provider", "THE_ID_PROVIDER"), tuple("error", "user_not_found"));
 
         // without id provider defined
         final Event event2 = createEvent(EventType.LOGIN_ERROR, "user_not_found");
         PrometheusExporter.instance().recordLoginError(event2);
-        assertMetric("keycloak_failed_login_attempts", 1, Tuple.of("provider", "keycloak"), Tuple.of("error", "user_not_found"));
-        assertMetric("keycloak_failed_login_attempts", 1, Tuple.of("provider", "THE_ID_PROVIDER"), Tuple.of("error", "user_not_found"));
+        assertMetric("keycloak_failed_login_attempts", 1, tuple("provider", "keycloak"), tuple("error", "user_not_found"));
+        assertMetric("keycloak_failed_login_attempts", 1, tuple("provider", "THE_ID_PROVIDER"), tuple("error", "user_not_found"));
     }
 
     @Test
     public void shouldCorrectlyCountRegister() throws IOException {
         // with id provider defined
-        final Event event1 = createEvent(EventType.REGISTER, Tuple.of("identity_provider", "THE_ID_PROVIDER"));
+        final Event event1 = createEvent(EventType.REGISTER, tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordRegistration(event1);
-        assertMetric("keycloak_registrations", 1, Tuple.of("provider", "THE_ID_PROVIDER"));
+        assertMetric("keycloak_registrations", 1, tuple("provider", "THE_ID_PROVIDER"));
 
         // without id provider defined
         final Event event2 = createEvent(EventType.REGISTER);
         PrometheusExporter.instance().recordRegistration(event2);
-        assertMetric("keycloak_registrations", 1, Tuple.of("provider", "keycloak"));
-        assertMetric("keycloak_registrations", 1, Tuple.of("provider", "THE_ID_PROVIDER"));
+        assertMetric("keycloak_registrations", 1, tuple("provider", "keycloak"));
+        assertMetric("keycloak_registrations", 1, tuple("provider", "THE_ID_PROVIDER"));
     }
 
     @Test
@@ -131,9 +131,9 @@ public class PrometheusExporterTest {
         event1.setResourceType(ResourceType.AUTHORIZATION_SCOPE);
         event1.setRealmId(MYREALM);
         PrometheusExporter.instance().recordGenericAdminEvent(event1);
-        assertMetric("keycloak_admin_event_ACTION", 1, Tuple.of("resource", "AUTHORIZATION_SCOPE"));
+        assertMetric("keycloak_admin_event_ACTION", 1, tuple("resource", "AUTHORIZATION_SCOPE"));
         PrometheusExporter.instance().recordGenericAdminEvent(event1);
-        assertMetric("keycloak_admin_event_ACTION", 2, Tuple.of("resource", "AUTHORIZATION_SCOPE"));
+        assertMetric("keycloak_admin_event_ACTION", 2, tuple("resource", "AUTHORIZATION_SCOPE"));
 
 
         final AdminEvent event2 = new AdminEvent();
@@ -141,8 +141,8 @@ public class PrometheusExporterTest {
         event2.setResourceType(ResourceType.CLIENT);
         event2.setRealmId(MYREALM);
         PrometheusExporter.instance().recordGenericAdminEvent(event2);
-        assertMetric("keycloak_admin_event_UPDATE", 1, Tuple.of("resource", "CLIENT"));
-        assertMetric("keycloak_admin_event_ACTION", 2, Tuple.of("resource", "AUTHORIZATION_SCOPE"));
+        assertMetric("keycloak_admin_event_UPDATE", 1, tuple("resource", "CLIENT"));
+        assertMetric("keycloak_admin_event_ACTION", 2, tuple("resource", "AUTHORIZATION_SCOPE"));
     }
 
     // TODO: realm separation!
@@ -193,6 +193,10 @@ public class PrometheusExporterTest {
         return createEvent(type, (String) null);
     }
 
+    static <L, R> Tuple<L, R> tuple(L left, R right) {
+        return new Tuple<>(left, right);
+    }
+
     private static final class Tuple<L, R> {
         final L left;
         final R right;
@@ -200,10 +204,6 @@ public class PrometheusExporterTest {
         private Tuple(L left, R right) {
             this.left = left;
             this.right = right;
-        }
-
-        static <L, R> Tuple<L, R> of(L left, R right) {
-            return new Tuple<>(left, right);
         }
     }
 }


### PR DESCRIPTION
Commits:
* 6c46795 : made tests working. disabled tests for IMPERSONATE events which are gonna be removed later
* ce81e09 : added `.editorconfig` for consistent formatting. took it from https://github.com/aerogear/aerogear-android-sdk/blob/40e8dc33674b2bcf620c3b00ba12d7fc9ce78ea8/.editorconfig
* 4e30387 : got rid of impersonate business logic as discussed with @pb82 and @josemigallas 
* 39cddae : Got rid of some static stuff. Singleton instance is static anyway
* d630897 : Added tests for different login cases and register cases
* 688330e : Add tests for login error - created Tuple class to use in tests
* 46ea119 : Add tests for generic events
* 911a34e : Some syntax sugar in tests
* 98803ee:  Tests for realm separation
