### PR TITLE
Fix hot-deploy on keycloak 4.1 (and up?)

### DIFF
--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListenerSpi.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListenerSpi.java
@@ -1,0 +1,30 @@
+package org.jboss.aerogear.keycloak.metrics;
+
+import org.keycloak.events.EventListenerSpi;
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+
+import java.util.EventListener;
+
+public class MetricsEventListenerSpi extends EventListenerSpi {
+
+    @Override
+    public boolean isInternal() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "Prometheus Metrics Provider";
+    }
+
+    @Override
+    public Class<? extends Provider> getProviderClass() {
+        return MetricsEventListener.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory> getProviderFactoryClass() {
+        return MetricsEventListenerFactory.class;
+    }
+}

--- a/src/main/resources/META-INF/services/org.keycloak.events.EventListenerSpi
+++ b/src/main/resources/META-INF/services/org.keycloak.events.EventListenerSpi
@@ -1,0 +1,1 @@
+org.jboss.aerogear.keycloak.metrics.MetricsEventListenerSpi


### PR DESCRIPTION

## Motivation
on Keycloak 4.1 the metrics provider could not be loaded by hot-deployment. Implementing
the EventListenerSpi fixed the problem:

## What
Implement EventListenerSpi 

## Why
enable hot-deploy on keacloak 4.1

## Verification Steps
1. copy jar into $KEYCLOAK_HOM/standalone/deployments/
2. watch keacloak load the SPI

