### PR TITLE
Readme cli update

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ To enable the event listener via the GUI interface, go to _Manage -> Events -> C
 
 To enable the event listener via the KeyCloak CLI, such as when building a Docker container, use these commands. (These commands assume /opt/jboss is the KeyCloak home directory, which is used on the _jboss/keycloak_ reference container on Docker Hub.)
 
-  /opt/jboss/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user _username_ --password _password_
-  /opt/jboss/keycloak/bin/kcadm.sh update events/config -s "eventsEnabled=true" -s "adminEventsEnabled=true" -s "eventsListeners+=metrics-listener"
-  /usr/bin/rm -f /opt/jboss/.keycloak/kcadm.config
+    /opt/jboss/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user _username_ --password _password_
+    /opt/jboss/keycloak/bin/kcadm.sh update events/config -s "eventsEnabled=true" -s "adminEventsEnabled=true" -s "eventsListeners+=metrics-listener"
+    /usr/bin/rm -f /opt/jboss/.keycloak/kcadm.config
 
 ## Metrics
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,15 @@ builds the jar and writes it to _build/libs_.
 
 ## Usage
 
-Just drop the jar into the _providers_ subdirectory of your KeyCloak installation. To enable the event listener go to _Manage -> Events -> Config_. The _Event Listeners_ configuration should have an entry named `metrics-listener`.
+Just drop the jar into the _providers_ subdirectory of your KeyCloak installation.
+
+To enable the event listener via the GUI interface, go to _Manage -> Events -> Config_. The _Event Listeners_ configuration should have an entry named `metrics-listener`.
+
+To enable the event listener via the KeyCloak CLI, such as when building a Docker container, use these commands. (These commands assume /opt/jboss is the KeyCloak home directory, which is used on the _jboss/keycloak_ reference container on Docker Hub.)
+
+  /opt/jboss/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user _username_ --password _password_
+  /opt/jboss/keycloak/bin/kcadm.sh update events/config -s "eventsEnabled=true" -s "adminEventsEnabled=true" -s "eventsListeners+=metrics-listener"
+  /usr/bin/rm -f /opt/jboss/.keycloak/kcadm.config
 
 ## Metrics
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To enable the event listener via the GUI interface, go to _Manage -> Events -> C
 
 To enable the event listener via the KeyCloak CLI, such as when building a Docker container, use these commands. (These commands assume /opt/jboss is the KeyCloak home directory, which is used on the _jboss/keycloak_ reference container on Docker Hub.)
 
-    /opt/jboss/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user _username_ --password _password_
+    /opt/jboss/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
     /opt/jboss/keycloak/bin/kcadm.sh update events/config -s "eventsEnabled=true" -s "adminEventsEnabled=true" -s "eventsListeners+=metrics-listener"
     /usr/bin/rm -f /opt/jboss/.keycloak/kcadm.config
 


### PR DESCRIPTION
## Motivation
To help others with configuring Docker containers to use keycloak-metrics-spi, I added a description how to enable it using the KeyCloak command-line interface (CLI) in addition to the GUI instructions already provided.

## What/How
Added lines to README.md with the KeyCloak CLI lines to enable keycloak-metrics-spi

## Why
CLI commands can be used for automation, such as for defining Docker containers.

## Verification Steps
Run the provided commands on any Docker container where keycloak-metrics-spi is installed. (If using a different base container than jboss/keycloak, then check if the /opt/jboss in the paths need to be adjusted to match the container's KeyCloak home.

## Checklist:

- [y] Code has been tested locally by PR requester
- [n] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task