### PR TITLE
fix NPE in identity provider retrieval

### DIFF
--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -120,8 +120,7 @@ public final class PrometheusExporter {
      * @param event Login event
      */
     public void recordLogin(final Event event) {
-        final String provider = event.getDetails()
-                .getOrDefault("identity_provider", PROVIDER_KEYCLOAK_OPENID);
+        final String provider = getIdentityProvider(event);
 
         totalLogins.labels(event.getRealmId(), provider).inc();
     }
@@ -132,8 +131,7 @@ public final class PrometheusExporter {
      * @param event Register event
      */
     public void recordRegistration(final Event event) {
-        final String provider = event.getDetails()
-                .getOrDefault("identity_provider", PROVIDER_KEYCLOAK_OPENID);
+        final String provider = getIdentityProvider(event);
 
         totalRegistrations.labels(event.getRealmId(), provider).inc();
     }
@@ -145,10 +143,27 @@ public final class PrometheusExporter {
      * @param event LoginError event
      */
     public void recordLoginError(final Event event) {
-        final String provider = event.getDetails()
-                .getOrDefault("identity_provider", PROVIDER_KEYCLOAK_OPENID);
+        final String provider = getIdentityProvider(event);
 
         totalFailedLoginAttempts.labels(event.getRealmId(), provider, event.getError()).inc();
+    }
+
+    /**
+     * Retrieve the identity prodiver name from event details or
+     * default to {@value #PROVIDER_KEYCLOAK_OPENID}.
+     *
+     * @param event User event
+     * @return      Identity provider name
+     */
+    private String getIdentityProvider(Event event) {
+        String identityProvider = null;
+        if (event.getDetails() != null) {
+            identityProvider = event.getDetails().get("identity_provider");
+        }
+        if (identityProvider == null) {
+            identityProvider = PROVIDER_KEYCLOAK_OPENID;
+        }
+        return identityProvider;
     }
 
     /**


### PR DESCRIPTION
## Motivation
With Keycloak 4.8.0.Final, some events can be raised without event details. Those events raised a NullPointerException in the PrometheusExporter.
We faced these NPE with _keycloak_failed_login_attempts{realm="...",provider="keycloak",error="invalid_code",}_.

## What
Check if event details is null before retrieving provider name.

## Verification Steps
I was not able to reproduce the bug outside random events in our production environment.