### PR TITLE
AEROGEAR-8213 - NPE in Keycloak logs from keycloak-metrics-spi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "net.nemerosa.versioning" version "2.8.2"
+}
+
 repositories {
     jcenter()
 }
@@ -32,5 +36,16 @@ dependencies {
 jar {
     from {
         configurations.bundleLib.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    manifest {
+        attributes(
+            'Built-By'       : System.properties['user.name'],
+            'Build-Timestamp': new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date()),
+            'Build-Revision' : versioning.info.commit,
+            'Created-By'     : "Gradle ${gradle.gradleVersion}",
+            'Build-Jdk'      : "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+            'Build-OS'       : "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}",
+            'Version'        : "${gradle.rootProject.version}"
+        )
     }
 }


### PR DESCRIPTION
Fixes https://issues.jboss.org/browse/AEROGEAR-8213

I was able to reproduce https://gist.github.com/grdryn/6266a02b39db81005053c9304a60e979 with the `latest` of keycloak apb but I wasn't able to find out how the error happened because I couldn't find any commit that had PrometheusExporter#recordGenericEvent in 108. But when I decompile the jar in the keycloak apb, I saw this: 

![screenshot from 2019-02-07 16-42-28](https://user-images.githubusercontent.com/376732/52415196-674e8a80-2af7-11e9-96a1-900dae1d3d03.png)

So, the counters were not created successfully. I didn't get how that happens but I added a null check for that.

----- 

UPDATE:

I did some improvement in the Gradle config so that the manifest file in the JAR file has more info. We just drop the JAR file into the Keycloak APB and it is nice to see what version we had there.

Now we have this in the JAR file:

```
Manifest-Version: 1.0
Build-Timestamp: 2019-02-07T16:58:37.301+0300
Built-By: aliok
Build-Revision: 7086a73efa3d73ef23fbeda400fb58b6d22d63d8
Build-OS: Linux amd64 4.14.13-300.fc27.x86_64
Version: 1.0-SNAPSHOT
Created-By: Gradle 4.0
Build-Jdk: 1.8.0_162 (Oracle Corporation 25.162-b12)
```