### PR TITLE
Make Keycloak and Prometheus versions be configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ $ ./gradlew jar
 
 builds the jar and writes it to _build/libs_.
 
+### Configurable versions for some packages
+
+You can build the project using a different version of Keycloak or Prometheus, running the command:
+
+```sh
+$ ./gradlew -PkeycloakVersion="4.7.0.Final" -PprometheusVersion="0.3.0" jar
+```
+
+or by changing the `gradle.properties` file in the root of the project.
+
 ## Usage
 
 Just drop the jar into the _providers_ subdirectory of your KeyCloak installation.

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.text.SimpleDateFormat
+
 plugins {
     id "net.nemerosa.versioning" version "2.8.2"
 }
@@ -21,13 +23,19 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    keycloakVersion=project.properties["keycloakVersion"]
+    prometheusVersion=project.properties["prometheusVersion"]
+}
+
+
 dependencies {
-    compile group: 'org.keycloak', name: 'keycloak-server-spi-private', version: '3.2.1.Final'
-    compile group: 'org.keycloak', name: 'keycloak-server-spi', version: '3.2.1.Final'
-    compile group: 'org.keycloak', name: 'keycloak-services', version: '3.2.1.Final'
+    compile group: 'org.keycloak', name: 'keycloak-server-spi-private', version: keycloakVersion
+    compile group: 'org.keycloak', name: 'keycloak-server-spi', version: keycloakVersion
+    compile group: 'org.keycloak', name: 'keycloak-services', version: keycloakVersion
     compile group: 'org.jboss.spec.javax.ws.rs', name: 'jboss-jaxrs-api_2.0_spec', version: '1.0.0.Final'
-    bundleLib group: 'io.prometheus', name: 'simpleclient_common', version: '0.3.0'
-    bundleLib group: 'io.prometheus', name: 'simpleclient_hotspot', version: '0.3.0'
+    bundleLib group: 'io.prometheus', name: 'simpleclient_common', version: prometheusVersion
+    bundleLib group: 'io.prometheus', name: 'simpleclient_hotspot', version: prometheusVersion
     configurations.compile.extendsFrom(configurations.bundleLib)
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
@@ -40,7 +48,7 @@ jar {
     manifest {
         attributes(
             'Built-By'       : System.properties['user.name'],
-            'Build-Timestamp': new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date()),
+            'Build-Timestamp': new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date()),
             'Build-Revision' : versioning.info.commit,
             'Created-By'     : "Gradle ${gradle.gradleVersion}",
             'Build-Jdk'      : "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+keycloakVersion=4.8.3.Final
+prometheusVersion=0.3.0


### PR DESCRIPTION
## Motivation
Fixes issue #28

## What
Made the version strings for Keycloak and Prometheus configurable.

## Why
We're using a newer version of Keycloak in production.

## How
Adding an external properties file.

## Verification Steps

Run:
```
$ ./gradlew -PkeycloakVersion="4.7.1.Final"  jar
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team 