### PR TITLE
Additional metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,45 @@ This counter counts every new user registration. It also distinguishes registrat
 keycloak_registrations{realm="test",provider="keycloak",} 1.0
 keycloak_registrations{realm="test",provider="github",} 1.0
 ```
+
+##### keycloak_request_duration
+This histogram records the response times per route and http method and puts them in one of five buckets:
+
+* Requests that take 2ms or less
+* Requests that take 10ms or less
+* Requests that take 100ms or less
+* Requests that take 1s or less
+* Any request that takes longer than 1s
+
+The response from this type of metrics has the following format:
+
+```c
+# HELP keycloak_request_duration Request duration
+# TYPE keycloak_request_duration histogram
+keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="2.0",} 0.0
+keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="10.0",} 1.0
+keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="100.0",} 2.0
+keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="1000.0",} 2.0
+keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="+Inf",} 2.0
+keycloak_request_duration_count{method="PUT",route="/admin/realms/openshift/clients/3scale",} 2.0
+keycloak_request_duration_sum{method="PUT",route="/admin/realms/openshift/clients/3scale",} 83.0
+```
+
+This tells you that there have been zero requests that took less than 2ms. There was one request that took less than 10ms. All the other requests took less than 100ms.
+
+Aside from the buckets there are also the `sum` and `count` metrics for every route and method. In the above example they tell you that there have been two requests total for this route & http method. The sum of all response times for this combination is 83ms.
+
+To get the average request duration over the last five minutes for the whole server you can use the following Prometheus query:
+
+```c
+rate(keycloak_request_duration_sum[5m]) / rate(keycloak_request_duration_count[5m])
+```
+
+##### keycloak_response_errors
+This counter counts the number of response errors (responses where the http status code is in the 400 or 500 range).
+
+```c
+# HELP keycloak_response_errors Total number of error responses
+# TYPE keycloak_response_errors counter
+keycloak_response_errors{code="500",method="GET",route="/",} 1
+```

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-all.zip

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
@@ -1,5 +1,6 @@
 package org.jboss.aerogear.keycloak.metrics;
 
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
@@ -7,7 +8,6 @@ import org.keycloak.services.resource.RealmResourceProvider;
 import org.keycloak.services.resource.RealmResourceProviderFactory;
 
 public class MetricsEndpointFactory implements RealmResourceProviderFactory {
-
     @Override
     public RealmResourceProvider create(KeycloakSession session) {
         return new MetricsEndpoint();
@@ -15,7 +15,11 @@ public class MetricsEndpointFactory implements RealmResourceProviderFactory {
 
     @Override
     public void init(Config.Scope config) {
-        // nothing to do
+        ResteasyProviderFactory.getInstance().getContainerRequestFilterRegistry()
+            .registerSingleton(MetricsFilter.instance());
+
+        ResteasyProviderFactory.getInstance().getContainerResponseFilterRegistry()
+            .registerSingleton(MetricsFilter.instance());
     }
 
     @Override

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilter.java
@@ -1,0 +1,41 @@
+package org.jboss.aerogear.keycloak.metrics;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+
+public final class MetricsFilter implements ContainerRequestFilter, ContainerResponseFilter {
+    private static final String METRICS_REQUEST_TIMESTAMP = "metrics.requestTimestamp";
+    private static final MetricsFilter INSTANCE = new MetricsFilter();
+
+    public static MetricsFilter instance() {
+        return INSTANCE;
+    }
+
+    private MetricsFilter() { }
+
+    @Override
+    public void filter(ContainerRequestContext req) {
+        req.setProperty(METRICS_REQUEST_TIMESTAMP, System.currentTimeMillis());
+    }
+
+    @Override
+    public void filter(ContainerRequestContext req, ContainerResponseContext res) {
+        String route = req.getUriInfo().getPath();
+        int status = res.getStatus();
+
+        // We are only interested in recording the response status if it was an error
+        // (either a 4xx or 5xx). No point in counting  the successful responses
+        if (status >= 400) {
+            PrometheusExporter.instance().recordResponseError(status, req.getMethod(), route);
+        }
+
+        // Record request duration if timestamp property is present
+        if (req.getProperty(METRICS_REQUEST_TIMESTAMP) != null) {
+            long time = (long) req.getProperty(METRICS_REQUEST_TIMESTAMP);
+            long dur = System.currentTimeMillis() - time;
+            PrometheusExporter.instance().recordRequestDuration(dur, req.getMethod(), route);
+        }
+    }
+}

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -1,6 +1,5 @@
 package org.jboss.aerogear.keycloak.metrics;
 
-import com.openshift.internal.restclient.model.BuildConfig;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Histogram;

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -1,7 +1,9 @@
 package org.jboss.aerogear.keycloak.metrics;
 
+import com.openshift.internal.restclient.model.BuildConfig;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
+import io.prometheus.client.Histogram;
 import io.prometheus.client.exporter.common.TextFormat;
 import io.prometheus.client.hotspot.DefaultExports;
 import org.jboss.logging.Logger;
@@ -24,11 +26,13 @@ public final class PrometheusExporter {
 
     private final static Logger logger = Logger.getLogger(PrometheusExporter.class);
 
-    // these fields are package private by on purpose
+    // these fields are package private on purpose
     final Map<String, Counter> counters = new HashMap<>();
     final Counter totalLogins;
     final Counter totalFailedLoginAttempts;
     final Counter totalRegistrations;
+    final Counter responseErrors;
+    final Histogram requestDuration;
 
     private PrometheusExporter() {
         // The metrics collector needs to be a singleton because requiring a
@@ -38,25 +42,38 @@ public final class PrometheusExporter {
         // anyway and all the Gauges are suggested to be static (it does not really make
         // sense to record the same metric in multiple places)
 
-        // package private by on purpose
+        // package private on purpose
         totalLogins = Counter.build()
             .name("keycloak_logins")
             .help("Total successful logins")
             .labelNames("realm", "provider")
             .register();
 
-        // package private by on purpose
+        // package private on purpose
         totalFailedLoginAttempts = Counter.build()
             .name("keycloak_failed_login_attempts")
             .help("Total failed login attempts")
             .labelNames("realm", "provider", "error")
             .register();
 
-        // package private by on purpose
+        // package private on purpose
         totalRegistrations = Counter.build()
             .name("keycloak_registrations")
             .help("Total registered users")
             .labelNames("realm", "provider")
+            .register();
+
+        responseErrors = Counter.build()
+            .name("keycloak_response_errors")
+            .help("Total number of error responses")
+            .labelNames("code", "method", "route")
+            .register();
+
+        requestDuration = Histogram.build()
+            .name("keycloak_request_duration")
+            .help("Request duration")
+            .buckets(2, 10, 100, 1000)
+            .labelNames("method", "route")
             .register();
 
         // Counters for all user events
@@ -157,6 +174,28 @@ public final class PrometheusExporter {
         final String provider = getIdentityProvider(event);
 
         totalFailedLoginAttempts.labels(event.getRealmId(), provider, event.getError()).inc();
+    }
+
+    /**
+     * Record the duration between one request and response
+     *
+     * @param amt The duration in milliseconds
+     * @param method HTTP method of the request
+     * @param route Request route / path
+     */
+    public void recordRequestDuration(double amt, String method, String route) {
+        requestDuration.labels(method, route).observe(amt);
+    }
+
+    /**
+     * Increase the response error count by a given method and route
+     *
+     * @param code The returned http status code
+     * @param method The request method used
+     * @param route The request route / path
+     */
+    public void recordResponseError(int code, String method, String route) {
+        responseErrors.labels(Integer.toString(code), method, route).inc();
     }
 
     /**


### PR DESCRIPTION
## Motivation
This PR adds two new metrics:

* **keycloak_request_duration**: measures server response times per route and http method
* **keycloak_response_errors**: counts response errors (responses in the 400 and 500 range).

ping @wei-lee This could be useful for mobile metrics too.

## Why
Those are two common metrics that were missing from the SPI.

## Notes

Because the request duration is measured for every http method of every route the number of additional metrics can be very large. I've tried to reduce it as much as possible by limiting the number of buckets of the histogram and not record the status code in this kind of metric.

But if we want a smaller result, we could think about only recording the overall response time and not record it per method and route.

## How
By adding a global request and response filter. The request filter adds a timestamp to every requests. The response filter uses this timestamp to measure the time it took the server to process the request. In the response filter we record this response time and also if the request failed.


## Verification Steps

1. Build the SPI from this branch and start Keycloak with it.
1. Open the metrics endpoint in a browser. You should see the new keycloak_request_duration metric. To actually see values for the keycloak_response_errors you wouls have to trigger a server error.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
