### PR TITLE
Add Label client_id and Add keycloak_registrations_errors metric

### DIFF
--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListener.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListener.java
@@ -22,6 +22,9 @@ public class MetricsEventListener implements EventListenerProvider {
             case REGISTER:
                 PrometheusExporter.instance().recordRegistration(event);
                 break;
+            case REGISTER_ERROR:
+                PrometheusExporter.instance().recordRegistrationError(event);
+                break;
             case LOGIN_ERROR:
                 PrometheusExporter.instance().recordLoginError(event);
                 break;

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -66,7 +66,7 @@ public final class PrometheusExporter {
         totalRegistrationsErrors = Counter.build()
             .name("keycloak_errors_registrations_total")
             .help("Total errors on registrations")
-            .labelNames("realm", "provider", "client_id")
+            .labelNames("realm", "provider", "error", "client_id")
             .register();
 
         responseErrors = Counter.build()

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -64,7 +64,7 @@ public final class PrometheusExporter {
             .register();
 
         totalRegistrationsErrors = Counter.build()
-            .name("keycloak_errors_registrations_total")
+            .name("keycloak_registrations_errors")
             .help("Total errors on registrations")
             .labelNames("realm", "provider", "error", "client_id")
             .register();

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -64,8 +64,8 @@ public final class PrometheusExporter {
             .register();
 
         totalRegistrationsErrors = Counter.build()
-            .name("keycloak_failed_registrations_attempts_total")
-            .help("Total failed registered users attempts")
+            .name("keycloak_errors_registrations_total")
+            .help("Total errors on registrations")
             .labelNames("realm", "provider", "client_id")
             .register();
 

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -47,80 +47,80 @@ public class PrometheusExporterTest {
 
     @Test
     public void shouldCorrectlyCountLoginWhenIdentityProviderIsDefined() throws IOException {
-        final Event login1 = createEvent(EventType.LOGIN, tuple("identity_provider", "THE_ID_PROVIDER"));
+        final Event login1 = createEvent(EventType.LOGIN, DEFAULT_REALM, "THE_CLIENT_ID", tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordLogin(login1);
-        assertMetric("keycloak_logins", 1, tuple("provider", "THE_ID_PROVIDER"));
+        assertMetric("keycloak_logins", 1, tuple("provider", "THE_ID_PROVIDER"), tuple("client_id", "THE_CLIENT_ID"));
 
-        final Event login2 = createEvent(EventType.LOGIN, tuple("identity_provider", "THE_ID_PROVIDER"));
+        final Event login2 = createEvent(EventType.LOGIN, DEFAULT_REALM, "THE_CLIENT_ID", tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordLogin(login2);
-        assertMetric("keycloak_logins", 2, tuple("provider", "THE_ID_PROVIDER"));
+        assertMetric("keycloak_logins", 2, tuple("provider", "THE_ID_PROVIDER"), tuple("client_id", "THE_CLIENT_ID"));
     }
 
     @Test
     public void shouldCorrectlyCountLoginWhenIdentityProviderIsNotDefined() throws IOException {
         final Event login1 = createEvent(EventType.LOGIN);
         PrometheusExporter.instance().recordLogin(login1);
-        assertMetric("keycloak_logins", 1, tuple("provider", "keycloak"));
+        assertMetric("keycloak_logins", 1, tuple("provider", "keycloak"), tuple("client_id", "THE_CLIENT_ID"));
 
         final Event login2 = createEvent(EventType.LOGIN);
         PrometheusExporter.instance().recordLogin(login2);
-        assertMetric("keycloak_logins", 2, tuple("provider", "keycloak"));
+        assertMetric("keycloak_logins", 2, tuple("provider", "keycloak"), tuple("client_id", "THE_CLIENT_ID"));
     }
 
     @Test
     public void shouldCorrectlyCountLoginsFromDifferentProviders() throws IOException {
         // with id provider defined
-        final Event login1 = createEvent(EventType.LOGIN, tuple("identity_provider", "THE_ID_PROVIDER"));
+        final Event login1 = createEvent(EventType.LOGIN, DEFAULT_REALM, "THE_CLIENT_ID", tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordLogin(login1);
-        assertMetric("keycloak_logins", 1, tuple("provider", "THE_ID_PROVIDER"));
+        assertMetric("keycloak_logins", 1, tuple("provider", "THE_ID_PROVIDER"), tuple("client_id", "THE_CLIENT_ID"));
 
         // without id provider defined
-        final Event login2 = createEvent(EventType.LOGIN);
+        final Event login2 = createEvent(EventType.LOGIN, DEFAULT_REALM, "THE_CLIENT_ID");
         PrometheusExporter.instance().recordLogin(login2);
-        assertMetric("keycloak_logins", 1, tuple("provider", "keycloak"));
-        assertMetric("keycloak_logins", 1, tuple("provider", "THE_ID_PROVIDER"));
+        assertMetric("keycloak_logins", 1, tuple("provider", "keycloak"), tuple("client_id", "THE_CLIENT_ID"));
+        assertMetric("keycloak_logins", 1, tuple("provider", "THE_ID_PROVIDER"), tuple("client_id", "THE_CLIENT_ID"));
     }
 
     @Test
     public void shouldRecordLoginsPerRealm() throws IOException {
         // realm 1
-        final Event login1 = createEvent(EventType.LOGIN, DEFAULT_REALM, null, tuple("identity_provider", "THE_ID_PROVIDER"));
+        final Event login1 = createEvent(EventType.LOGIN, DEFAULT_REALM, "THE_CLIENT_ID", tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordLogin(login1);
 
         // realm 2
-        final Event login2 = createEvent(EventType.LOGIN, "OTHER_REALM", null, tuple("identity_provider", "THE_ID_PROVIDER"));
+        final Event login2 = createEvent(EventType.LOGIN, "OTHER_REALM", "THE_CLIENT_ID", tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordLogin(login2);
 
-        assertMetric("keycloak_logins", 1, DEFAULT_REALM, tuple("provider", "THE_ID_PROVIDER"));
-        assertMetric("keycloak_logins", 1, "OTHER_REALM", tuple("provider", "THE_ID_PROVIDER"));
+        assertMetric("keycloak_logins", 1, DEFAULT_REALM, tuple("provider", "THE_ID_PROVIDER"), tuple("client_id", "THE_CLIENT_ID"));
+        assertMetric("keycloak_logins", 1, "OTHER_REALM", tuple("provider", "THE_ID_PROVIDER"), tuple("client_id", "THE_CLIENT_ID"));
     }
 
     @Test
     public void shouldCorrectlyCountLoginError() throws IOException {
         // with id provider defined
-        final Event event1 = createEvent(EventType.LOGIN_ERROR, DEFAULT_REALM, "user_not_found", tuple("identity_provider", "THE_ID_PROVIDER"));
+        final Event event1 = createEvent(EventType.LOGIN_ERROR, DEFAULT_REALM, "THE_CLIENT_ID", "user_not_found", tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordLoginError(event1);
-        assertMetric("keycloak_failed_login_attempts", 1, tuple("provider", "THE_ID_PROVIDER"), tuple("error", "user_not_found"));
+        assertMetric("keycloak_failed_login_attempts", 1, tuple("provider", "THE_ID_PROVIDER"), tuple("error", "user_not_found"), tuple("client_id", "THE_CLIENT_ID"));
 
         // without id provider defined
-        final Event event2 = createEvent(EventType.LOGIN_ERROR, DEFAULT_REALM, "user_not_found");
+        final Event event2 = createEvent(EventType.LOGIN_ERROR, DEFAULT_REALM, "THE_CLIENT_ID", "user_not_found");
         PrometheusExporter.instance().recordLoginError(event2);
-        assertMetric("keycloak_failed_login_attempts", 1, tuple("provider", "keycloak"), tuple("error", "user_not_found"));
-        assertMetric("keycloak_failed_login_attempts", 1, tuple("provider", "THE_ID_PROVIDER"), tuple("error", "user_not_found"));
+        assertMetric("keycloak_failed_login_attempts", 1, tuple("provider", "keycloak"), tuple("error", "user_not_found"), tuple("client_id", "THE_CLIENT_ID"));
+        assertMetric("keycloak_failed_login_attempts", 1, tuple("provider", "THE_ID_PROVIDER"), tuple("error", "user_not_found"), tuple("client_id", "THE_CLIENT_ID"));
     }
 
     @Test
     public void shouldCorrectlyCountRegister() throws IOException {
         // with id provider defined
-        final Event event1 = createEvent(EventType.REGISTER, tuple("identity_provider", "THE_ID_PROVIDER"));
+        final Event event1 = createEvent(EventType.REGISTER, DEFAULT_REALM, "THE_CLIENT_ID", tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordRegistration(event1);
-        assertMetric("keycloak_registrations", 1, tuple("provider", "THE_ID_PROVIDER"));
+        assertMetric("keycloak_registrations", 1, tuple("provider", "THE_ID_PROVIDER"), tuple("client_id", "THE_CLIENT_ID"));
 
         // without id provider defined
-        final Event event2 = createEvent(EventType.REGISTER);
+        final Event event2 = createEvent(EventType.REGISTER, DEFAULT_REALM, "THE_CLIENT_ID");
         PrometheusExporter.instance().recordRegistration(event2);
-        assertMetric("keycloak_registrations", 1, tuple("provider", "keycloak"));
-        assertMetric("keycloak_registrations", 1, tuple("provider", "THE_ID_PROVIDER"));
+        assertMetric("keycloak_registrations", 1, tuple("provider", "keycloak"), tuple("client_id", "THE_CLIENT_ID"));
+        assertMetric("keycloak_registrations", 1, tuple("provider", "THE_ID_PROVIDER"), tuple("client_id", "THE_CLIENT_ID"));
     }
 
     @Test
@@ -214,10 +214,11 @@ public class PrometheusExporterTest {
         this.assertMetric(metricName, metricValue, DEFAULT_REALM, labels);
     }
 
-    private Event createEvent(EventType type, String realm, String error, Tuple<String, String>... tuples) {
+    private Event createEvent(EventType type, String realm, String clientId, String error, Tuple<String, String>... tuples) {
         final Event event = new Event();
         event.setType(type);
         event.setRealmId(realm);
+        event.setClientId(clientId);
         if (tuples != null) {
             event.setDetails(new HashMap<>());
             for (Tuple<String, String> tuple : tuples) {
@@ -234,11 +235,19 @@ public class PrometheusExporterTest {
     }
 
     private Event createEvent(EventType type, Tuple<String, String>... tuples) {
-        return this.createEvent(type, DEFAULT_REALM, null, tuples);
+        return this.createEvent(type, DEFAULT_REALM, "THE_CLIENT_ID", (String) null, tuples);
+    }
+
+    private Event createEvent(EventType type, String realm, String clientId, Tuple<String, String>... tuples) {
+        return this.createEvent(type, realm, clientId, (String) null, tuples);
+    }
+
+    private Event createEvent(EventType type, String realm, Tuple<String, String>... tuples) {
+        return this.createEvent(type, realm, "THE_CLIENT_ID", (String) null, tuples);
     }
 
     private Event createEvent(EventType type) {
-        return createEvent(type, DEFAULT_REALM, (String) null);
+        return createEvent(type, DEFAULT_REALM, "THE_CLIENT_ID",(String) null);
     }
 
     private static <L, R> Tuple<L, R> tuple(L left, R right) {


### PR DESCRIPTION
## Motivation
Collect metrics per client to identify usage and errors for each application.

## What
Added metric `keycloak_registrations_errors`

Added Label `client_id` on metrics : 
- keycloak_logins
- keycloak_failed_login_attempts
- keycloak_registrations
- keycloak_errors_registrations_total



