### PR TITLE
feat: Change request duration histogram buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,31 +121,39 @@ keycloak_registrations_errors{realm="test",provider="keycloak",error="email_in_u
 ```
 
 ##### keycloak_request_duration
-This histogram records the response times per route and http method and puts them in one of five buckets:
+This histogram records the response times per route and http method and puts them in one of nine buckets:
 
-* Requests that take 2ms or less
-* Requests that take 10ms or less
+* Requests that take 50ms or less
 * Requests that take 100ms or less
+* Requests that take 250ms or less
+* Requests that take 500ms or less
 * Requests that take 1s or less
-* Any request that takes longer than 1s
+* Requests that take 2s or less
+* Requests that take 10s or less
+* Requests that take 30s or less
+* Any request that takes longer than 30s
 
 The response from this type of metrics has the following format:
 
 ```c
 # HELP keycloak_request_duration Request duration
 # TYPE keycloak_request_duration histogram
-keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="2.0",} 0.0
-keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="10.0",} 1.0
-keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="100.0",} 2.0
-keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="1000.0",} 2.0
+keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="50.0",} 0.0
+keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="100.0",} 0.0
+keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="250.0",} 0.0
+keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="500.0",} 0.0
+keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="1000.0",} 1.0
+keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="2000.0",} 2.0
+keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="10000.0",} 2.0
+keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="30000.0",} 2.0
 keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="+Inf",} 2.0
 keycloak_request_duration_count{method="PUT",route="/admin/realms/openshift/clients/3scale",} 2.0
-keycloak_request_duration_sum{method="PUT",route="/admin/realms/openshift/clients/3scale",} 83.0
+keycloak_request_duration_sum{method="PUT",route="/admin/realms/openshift/clients/3scale",} 3083.0
 ```
 
-This tells you that there have been zero requests that took less than 2ms. There was one request that took less than 10ms. All the other requests took less than 100ms.
+This tells you that there have been zero requests that took less than 500ms. There was one request that took less than 1s. All the other requests took less than 2s.
 
-Aside from the buckets there are also the `sum` and `count` metrics for every route and method. In the above example they tell you that there have been two requests total for this route & http method. The sum of all response times for this combination is 83ms.
+Aside from the buckets there are also the `sum` and `count` metrics for every route and method. In the above example they tell you that there have been two requests total for this route & http method. The sum of all response times for this combination is 3083ms.
 
 To get the average request duration over the last five minutes for the whole server you can use the following Prometheus query:
 

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -78,7 +78,7 @@ public final class PrometheusExporter {
         requestDuration = Histogram.build()
             .name("keycloak_request_duration")
             .help("Request duration")
-            .buckets(2, 10, 100, 1000)
+            .buckets(50, 100, 250, 500, 1000, 2000, 10000, 30000)
             .labelNames("method", "route")
             .register();
 


### PR DESCRIPTION
## Motivation
Creating Prometheus alerts requires the request duration buckets to be defined based on the SLI targets.

## What
Updating keycloak request duration histogram buckets

## Verification Steps
None required

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 

