### PR TITLE
Support for pushing metrics to a pushgateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ To enable the event listener via the Keycloak CLI, such as when building a Docke
     /opt/jboss/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
     /opt/jboss/keycloak/bin/kcadm.sh update events/config -s "eventsEnabled=true" -s "adminEventsEnabled=true" -s "eventsListeners+=metrics-listener"
     /usr/bin/rm -f /opt/jboss/.keycloak/kcadm.config
+    
+### PushGateway
+
+If you are running keycloak in a cluster or if you are running behind a load balancer, you might have problems scraping
+the metrics endpoint of each node. To fix this, you can push your metrics to a PushGateway. 
+
+[Prometheus PushGateway](https://github.com/prometheus/pushgateway)
+
+You can enable pushing to PushGateway by setting the environment variable ```PROMETHEUS_PUSHGATEWAY_ADDRESS``` in the keycloak
+instance. The format is host:port or ip:port of the Pushgateway.
 
 ## Metrics
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,11 @@ dependencies {
     compile group: 'org.jboss.spec.javax.ws.rs', name: 'jboss-jaxrs-api_2.0_spec', version: '1.0.0.Final'
     bundleLib group: 'io.prometheus', name: 'simpleclient_common', version: prometheusVersion
     bundleLib group: 'io.prometheus', name: 'simpleclient_hotspot', version: prometheusVersion
+    bundleLib group: 'io.prometheus', name: 'simpleclient_pushgateway', version: prometheusVersion
     configurations.compile.extendsFrom(configurations.bundleLib)
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
 }
 
 jar {

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -13,6 +13,8 @@ import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.OperationType;
 
 import java.io.*;
+import java.net.InetAddress;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -283,7 +285,9 @@ public final class PrometheusExporter {
     private void push() {
         if(PUSH_GATEWAY != null) {
             try {
-                PUSH_GATEWAY.pushAdd(CollectorRegistry.defaultRegistry, "keycloak");
+                String instanceIp = InetAddress.getLocalHost().getHostAddress();
+                Map<String, String> groupingKey = Collections.singletonMap("instance", instanceIp);
+                PUSH_GATEWAY.pushAdd(CollectorRegistry.defaultRegistry, "keycloak", groupingKey);
             } catch (IOException e) {
                 logger.error("Unable to send to prometheus PushGateway", e);
             }

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -3,6 +3,7 @@ package org.jboss.aerogear.keycloak.metrics;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Histogram;
+import io.prometheus.client.exporter.PushGateway;
 import io.prometheus.client.exporter.common.TextFormat;
 import io.prometheus.client.hotspot.DefaultExports;
 import org.jboss.logging.Logger;
@@ -14,6 +15,7 @@ import org.keycloak.events.admin.OperationType;
 import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public final class PrometheusExporter {
 
@@ -21,7 +23,7 @@ public final class PrometheusExporter {
     private final static String ADMIN_EVENT_PREFIX = "keycloak_admin_event_";
     private final static String PROVIDER_KEYCLOAK_OPENID = "keycloak";
 
-    private final static PrometheusExporter INSTANCE = new PrometheusExporter();
+    private static PrometheusExporter INSTANCE;
 
     private final static Logger logger = Logger.getLogger(PrometheusExporter.class);
 
@@ -33,6 +35,7 @@ public final class PrometheusExporter {
     final Counter totalRegistrationsErrors;
     final Counter responseErrors;
     final Histogram requestDuration;
+    final PushGateway PUSH_GATEWAY;
 
     private PrometheusExporter() {
         // The metrics collector needs to be a singleton because requiring a
@@ -41,6 +44,8 @@ public final class PrometheusExporter {
         // or intentional but better to avoid this. The metrics object is single-instance
         // anyway and all the Gauges are suggested to be static (it does not really make
         // sense to record the same metric in multiple places)
+
+        PUSH_GATEWAY = buildPushGateWay();
 
         // package private on purpose
         totalLogins = Counter.build()
@@ -101,7 +106,10 @@ public final class PrometheusExporter {
         DefaultExports.initialize();
     }
 
-    public static PrometheusExporter instance() {
+    public static synchronized PrometheusExporter instance() {
+        if (INSTANCE == null) {
+            INSTANCE = new PrometheusExporter();
+        }
         return INSTANCE;
     }
 
@@ -132,6 +140,7 @@ public final class PrometheusExporter {
             return;
         }
         counters.get(counterName).labels(nullToEmpty(event.getRealmId())).inc();
+        pushAsync();
     }
 
     /**
@@ -146,6 +155,7 @@ public final class PrometheusExporter {
             return;
         }
         counters.get(counterName).labels(nullToEmpty(event.getRealmId()), event.getResourceType().name()).inc();
+        pushAsync();
     }
 
     /**
@@ -157,6 +167,7 @@ public final class PrometheusExporter {
         final String provider = getIdentityProvider(event);
 
         totalLogins.labels(nullToEmpty(event.getRealmId()), provider, nullToEmpty(event.getClientId())).inc();
+        pushAsync();
     }
 
     /**
@@ -168,6 +179,7 @@ public final class PrometheusExporter {
         final String provider = getIdentityProvider(event);
 
         totalRegistrations.labels(nullToEmpty(event.getRealmId()), provider, nullToEmpty(event.getClientId())).inc();
+        pushAsync();
     }
 
     /**
@@ -179,6 +191,7 @@ public final class PrometheusExporter {
         final String provider = getIdentityProvider(event);
 
         totalRegistrationsErrors.labels(nullToEmpty(event.getRealmId()), provider, nullToEmpty(event.getError()), nullToEmpty(event.getClientId())).inc();
+        pushAsync();
     }
 
     /**
@@ -190,6 +203,7 @@ public final class PrometheusExporter {
         final String provider = getIdentityProvider(event);
 
         totalFailedLoginAttempts.labels(nullToEmpty(event.getRealmId()), provider, nullToEmpty(event.getError()), nullToEmpty(event.getClientId())).inc();
+        pushAsync();
     }
 
     /**
@@ -201,6 +215,7 @@ public final class PrometheusExporter {
      */
     public void recordRequestDuration(double amt, String method, String route) {
         requestDuration.labels(method, route).observe(amt);
+        pushAsync();
     }
 
     /**
@@ -212,6 +227,7 @@ public final class PrometheusExporter {
      */
     public void recordResponseError(int code, String method, String route) {
         responseErrors.labels(Integer.toString(code), method, route).inc();
+        pushAsync();
     }
 
     /**
@@ -243,6 +259,35 @@ public final class PrometheusExporter {
         final Writer writer = new BufferedWriter(new OutputStreamWriter(stream));
         TextFormat.write004(writer, CollectorRegistry.defaultRegistry.metricFamilySamples());
         writer.flush();
+    }
+
+    /**
+     * Build a prometheus pushgateway if an address is defined in environment.
+     *
+     * @return PushGateway
+     */
+    private PushGateway buildPushGateWay() {
+        // host:port or ip:port of the Pushgateway.
+        String host = System.getenv("PROMETHEUS_PUSHGATEWAY_ADDRESS");
+        if(host != null){
+            return new PushGateway(host);
+        } else {
+            return null;
+        }
+    }
+
+    public void pushAsync() {
+        CompletableFuture.runAsync(() -> push());
+    }
+
+    private void push() {
+        if(PUSH_GATEWAY != null) {
+            try {
+                PUSH_GATEWAY.pushAdd(CollectorRegistry.defaultRegistry, "keycloak");
+            } catch (IOException e) {
+                logger.error("Unable to send to prometheus PushGateway", e);
+            }
+        }
     }
 
     private String buildCounterName(OperationType type) {


### PR DESCRIPTION
## Motivation
Fixes #50

## What
Added support for pushing metrics to a pushgateway

## Why
When running keycloak in a cluster behind a load balancer, we needed a way to read metrics from each instance independently.

## How
Added an environment variable ```PROMETHEUS_PUSHGATEWAY_ADDRESS``` that takes a value in the format of host:port or ip:port of the Pushgateway. If set, metrics will automatically be pushed to the pushgateway.

## Verification Steps

1. Spawn a prometheus pushgateway. For example run `docker run -p 9091:9091 prom/pushgateway`
2. Spawn a keycloak instance with the environment variable ```PROMETHEUS_PUSHGATEWAY_ADDRESS``` set to `localhost:9091`
3. Do stuff in keycloak
4. Verify that metrics are pushed to the pushgateway. You can find them on `http://localhost:9091`

Also verify that the pushgateway is disabled and that things are running normally, if you dont set the ```PROMETHEUS_PUSHGATEWAY_ADDRESS```  environment variable.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Additional notes
I updated the way the PrometheusExporter singleton is made, in order to to enable resetting it in unittests. This makes unittesting a singleton pattern bearable.