### PR TITLE
remove route from request duration to avoid creating an excessive num…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
 }
 
 group 'org.jboss.aerogear'
-version '1.0.6-SNAPSHOT'
+version '2.0.1-SNAPSHOT'
 
 apply plugin: 'java'
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
 }
 
 group 'org.jboss.aerogear'
-version '1.0.5-SNAPSHOT'
+version '1.0.6-SNAPSHOT'
 
 apply plugin: 'java'
 

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilter.java
@@ -55,7 +55,7 @@ public final class MetricsFilter implements ContainerRequestFilter, ContainerRes
             long time = (long) req.getProperty(METRICS_REQUEST_TIMESTAMP);
             long dur = System.currentTimeMillis() - time;
             LOG.trace("Duration is calculated as " + dur + " ms.");
-            PrometheusExporter.instance().recordRequestDuration(dur, req.getMethod(), route);
+            PrometheusExporter.instance().recordRequestDuration(dur, req.getMethod());
         }
     }
 

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -86,7 +86,7 @@ public final class PrometheusExporter {
             .name("keycloak_request_duration")
             .help("Request duration")
             .buckets(50, 100, 250, 500, 1000, 2000, 10000, 30000)
-            .labelNames("method", "route")
+            .labelNames("method")
             .register();
 
         // Counters for all user events
@@ -213,10 +213,9 @@ public final class PrometheusExporter {
      *
      * @param amt    The duration in milliseconds
      * @param method HTTP method of the request
-     * @param route  Request route / path
      */
-    public void recordRequestDuration(double amt, String method, String route) {
-        requestDuration.labels(method, route).observe(amt);
+    public void recordRequestDuration(double amt, String method) {
+        requestDuration.labels(method).observe(amt);
         pushAsync();
     }
 

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -166,9 +166,9 @@ public class PrometheusExporterTest {
 
     @Test
     public void shouldCorrectlyRecordResponseDurations() throws IOException {
-        PrometheusExporter.instance().recordRequestDuration(5, "GET", "/");
-        assertGenericMetric("keycloak_request_duration_count", 1, tuple("method", "GET"), tuple("route", "/"));
-        assertGenericMetric("keycloak_request_duration_sum", 5, tuple("method", "GET"), tuple("route", "/"));
+        PrometheusExporter.instance().recordRequestDuration(5, "GET");
+        assertGenericMetric("keycloak_request_duration_count", 1, tuple("method", "GET"));
+        assertGenericMetric("keycloak_request_duration_sum", 5, tuple("method", "GET"));
     }
 
     @Test


### PR DESCRIPTION
…ber of metrics

Fixes #64 and #63 

This PR removes the `route` label from the request duration histograms. With that label a histogram was generated for every route. With a large number of users this can quickly become excessive.

Without the `route` label in the metric we still record the request durations of all those requests. But they are aggregated into a single Histogram.

Verification steps:

1. a version of the spi with this change is hosted under: https://github.com/pb82/files/raw/master/keycloak-metrics-spi-1.0.5.jar
2. deploy Keycloak with the operator and use the above url to import the metrics spi (see here: https://github.com/keycloak/keycloak-operator/blob/master/deploy/examples/keycloak/keycloak.yaml#L10)
3. Create a few users and log in as them. Check the metrics endpoint (<base>/auth/realms/master/metrics). There should only be one histogram exported.