### PR TITLE
Remove route from response errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ keycloak_registrations_errors{realm="test",provider="keycloak",error="email_in_u
 ```
 
 ##### keycloak_request_duration
-This histogram records the response times per route and http method and puts them in one of nine buckets:
+This histogram records the response times per http method and puts them in one of nine buckets:
 
 * Requests that take 50ms or less
 * Requests that take 100ms or less
@@ -148,22 +148,22 @@ The response from this type of metrics has the following format:
 ```c
 # HELP keycloak_request_duration Request duration
 # TYPE keycloak_request_duration histogram
-keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="50.0",} 0.0
-keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="100.0",} 0.0
-keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="250.0",} 0.0
-keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="500.0",} 0.0
-keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="1000.0",} 1.0
-keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="2000.0",} 2.0
-keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="10000.0",} 2.0
-keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="30000.0",} 2.0
-keycloak_request_duration_bucket{method="PUT",route="/admin/realms/openshift/clients/3scale",le="+Inf",} 2.0
-keycloak_request_duration_count{method="PUT",route="/admin/realms/openshift/clients/3scale",} 2.0
-keycloak_request_duration_sum{method="PUT",route="/admin/realms/openshift/clients/3scale",} 3083.0
+keycloak_request_duration_bucket{method="PUT",le="50.0",} 0.0
+keycloak_request_duration_bucket{method="PUT",le="100.0",} 0.0
+keycloak_request_duration_bucket{method="PUT",le="250.0",} 0.0
+keycloak_request_duration_bucket{method="PUT",le="500.0",} 0.0
+keycloak_request_duration_bucket{method="PUT",le="1000.0",} 1.0
+keycloak_request_duration_bucket{method="PUT",le="2000.0",} 2.0
+keycloak_request_duration_bucket{method="PUT",le="10000.0",} 2.0
+keycloak_request_duration_bucket{method="PUT",le="30000.0",} 2.0
+keycloak_request_duration_bucket{method="PUT",le="+Inf",} 2.0
+keycloak_request_duration_count{method="PUT",} 2.0
+keycloak_request_duration_sum{method="PUT",} 3083.0
 ```
 
 This tells you that there have been zero requests that took less than 500ms. There was one request that took less than 1s. All the other requests took less than 2s.
 
-Aside from the buckets there are also the `sum` and `count` metrics for every route and method. In the above example they tell you that there have been two requests total for this route & http method. The sum of all response times for this combination is 3083ms.
+Aside from the buckets there are also the `sum` and `count` metrics for every method. In the above example they tell you that there have been two requests total for this http method. The sum of all response times for this combination is 3083ms.
 
 To get the average request duration over the last five minutes for the whole server you can use the following Prometheus query:
 
@@ -177,7 +177,7 @@ This counter counts the number of response errors (responses where the http stat
 ```c
 # HELP keycloak_response_errors Total number of error responses
 # TYPE keycloak_response_errors counter
-keycloak_response_errors{code="500",method="GET",route="/",} 1
+keycloak_response_errors{code="500",method="GET",} 1
 ```
 
 ## Grafana Dashboard

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilter.java
@@ -39,13 +39,12 @@ public final class MetricsFilter implements ContainerRequestFilter, ContainerRes
 
     @Override
     public void filter(ContainerRequestContext req, ContainerResponseContext res) {
-        String route = req.getUriInfo().getPath();
         int status = res.getStatus();
 
         // We are only interested in recording the response status if it was an error
         // (either a 4xx or 5xx). No point in counting  the successful responses
         if (status >= 400) {
-            PrometheusExporter.instance().recordResponseError(status, req.getMethod(), route);
+            PrometheusExporter.instance().recordResponseError(status, req.getMethod());
         }
 
         // Record request duration if timestamp property is present

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -79,7 +79,7 @@ public final class PrometheusExporter {
         responseErrors = Counter.build()
             .name("keycloak_response_errors")
             .help("Total number of error responses")
-            .labelNames("code", "method", "route")
+            .labelNames("code", "method")
             .register();
 
         requestDuration = Histogram.build()
@@ -220,14 +220,13 @@ public final class PrometheusExporter {
     }
 
     /**
-     * Increase the response error count by a given method and route
+     * Increase the response error count by a given method and response code
      *
      * @param code   The returned http status code
      * @param method The request method used
-     * @param route  The request route / path
      */
-    public void recordResponseError(int code, String method, String route) {
-        responseErrors.labels(Integer.toString(code), method, route).inc();
+    public void recordResponseError(int code, String method) {
+        responseErrors.labels(Integer.toString(code), method).inc();
         pushAsync();
     }
 

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -173,8 +173,8 @@ public class PrometheusExporterTest {
 
     @Test
     public void shouldCorrectlyRecordResponseErrors() throws IOException {
-        PrometheusExporter.instance().recordResponseError(500, "POST", "/");
-        assertGenericMetric("keycloak_response_errors", 1, tuple("code", "500"), tuple("method", "POST"), tuple("route", "/"));
+        PrometheusExporter.instance().recordResponseError(500, "POST");
+        assertGenericMetric("keycloak_response_errors", 1, tuple("code", "500"), tuple("method", "POST"));
     }
 
     @Test


### PR DESCRIPTION
## Motivation
The `response_errors` also included the route label, which can lead to a lots of data. This is pretty similar to #65 

## What
Removes the route from the `response_errors`. Also, I've updated the readme to align with the current responses.

## Why
Avoid creating an excessive number of metrics.

## Verification Steps
This part of the code is covered by test.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
 

