### PR TITLE
PROMETHEUS_PUSHGATEWAY_ADDRESS: Support for https URL. Take 2.

### DIFF
--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -263,6 +263,11 @@ public final class PrometheusExporter {
         writer.flush();
     }
 
+    /**
+     * Build a prometheus pushgateway if an address is defined in environment.
+     *
+     * @return PushGateway
+     */
     private PushGateway buildPushGateWay() {
         // host:port or ip:port of the Pushgateway.
         PushGateway pg = null;

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -196,6 +196,14 @@ public class PrometheusExporterTest {
     }
 
     @Test
+    public void shouldBuildPushgatewayWithHttps() throws IOException {
+        final String envVar = "PROMETHEUS_PUSHGATEWAY_ADDRESS";
+        final String address = "https://localhost:9091";
+        environmentVariables.set(envVar, address);
+        Assert.assertNotNull(PrometheusExporter.instance().PUSH_GATEWAY);
+    }
+
+    @Test
     public void shouldNotBuildPushgateway() throws IOException {
         Assert.assertNull(PrometheusExporter.instance().PUSH_GATEWAY);
     }


### PR DESCRIPTION
PROMETHEUS_PUSHGATEWAY_ADDRESS: allow prometheus push gateways with https. Still support host:port for backwards compatibility.