### PR TITLE
Add jboss-deployment-structure.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,12 @@ or by changing the `gradle.properties` file in the root of the project.
 
 - Drop the [jar](https://github.com/aerogear/keycloak-metrics-spi/releases/latest) into the _/opt/jboss/keycloak/standalone/deployments/_ subdirectory of your Keycloak installation.
 
-- Add a new spi `eventsListeners` to the keycloak-server subsystem in `/opt/jboss/keycloak/standalone/configuration/standalone.xml`
-```xml
-        <subsystem xmlns="urn:jboss:domain:keycloak-server:1.1">
-        ...
-        <!-- ADD THIS BLOCK -->
-            <spi name="eventsListeners">
-                <provider name="metrics-listener" enabled="true"/>
-            </spi>
-        <!-- END OF BLOCK -->
-        ...
-        </subsystem>
+- Touch a dodeploy file into the _/opt/jboss/keycloak/standalone/deployments/_ subdirectory of your Keycloak installation.
+
+```bash
+# If your jar file is `keycloak-metrics-spi-2.0.2.jar`
+cd /opt/jboss/keycloak/standalone/deployments/
+touch keycloak-metrics-spi-2.0.2.jar.dodeploy
 ```
 - Restart the keycloak service.
 

--- a/src/main/resources/jboss-deployment-structure.xml
+++ b/src/main/resources/jboss-deployment-structure.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-deployment-structure>
+    <deployment>
+        <dependencies>
+            <module name="org.keycloak.keycloak-server-spi" />
+            <module name="org.keycloak.keycloak-server-spi-private" />
+            <module name="org.keycloak.keycloak-services" />
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>


### PR DESCRIPTION
Add jboss-deployment-structure.xml and Update README

## Motivation
Make the installation easier by adding a  jboss-deployment-structure.xml  file

## What
Add the  jboss-deployment-structure.xml  file

## Why
Make the installation easier 

## How


## Verification Steps
Add the steps required to check this change. Following an example.
 
Touch a dodeploy file into the _/opt/jboss/keycloak/standalone/deployments/_ subdirectory of your Keycloak installation.
```bash
# If your jar file is `keycloak-metrics-spi-2.0.2.jar`
cd /opt/jboss/keycloak/standalone/deployments/
touch keycloak-metrics-spi-2.0.2.jar.dodeploy
```

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 

