### PR TITLE
Update(dependencies): keycloak

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-keycloakVersion=4.8.3.Final
+keycloakVersion=11.0.2
 prometheusVersion=0.3.0


### PR DESCRIPTION
##Motivation
Keycloak version has been updated to 11.0.2 as part of the INTLY-10145.
This also has the side affect of resolving most issues in INTLY10143.

**JIRA** https://issues.redhat.com/browse/INTLY-10145

## How
By referencing the documentation for breaking changes.
Running the test and building locally

### Verify
These steps were done a rhmi cluster with 2.7 installed and the operator running locally 
- setup github as the idp for the cluster
- Logged into 3scale a few times with a github user
- Actively on the rhsso dashboard in grafana will be seen for the loggins.
- Stop the rhmi operator locally
- In the CR for rhsso replace the `keycloack-metric-spi` with the updated version hosted else where.
- Allow some time for the pods in rhsso to redeployed and operators to reconcile any other changes. 
- Log back into 3scale few times as the github user
- Expected: the login activity is seen on the rhsso dashboard in grafana.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 

