### PR TITLE
Generic events by client_id

### DIFF
--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -126,7 +126,7 @@ public final class PrometheusExporter {
         if (isAdmin) {
             counter.labelNames("realm", "resource").help("Generic KeyCloak Admin event");
         } else {
-            counter.labelNames("realm").help("Generic KeyCloak User event");
+            counter.labelNames("realm", "client_id").help("Generic KeyCloak User event");
         }
 
         return counter.register();
@@ -143,7 +143,7 @@ public final class PrometheusExporter {
             logger.warnf("Counter for event type %s does not exist. Realm: %s", event.getType().name(), nullToEmpty(event.getRealmId()));
             return;
         }
-        counters.get(counterName).labels(nullToEmpty(event.getRealmId())).inc();
+        counters.get(counterName).labels(nullToEmpty(event.getRealmId()), nullToEmpty(event.getClientId())).inc();
         pushAsync();
     }
 

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -132,15 +132,15 @@ public class PrometheusExporterTest {
     public void shouldCorrectlyRecordGenericEvents() throws IOException {
         final Event event1 = createEvent(EventType.UPDATE_EMAIL);
         PrometheusExporter.instance().recordGenericEvent(event1);
-        assertMetric("keycloak_user_event_UPDATE_EMAIL", 1);
+        assertMetric("keycloak_user_event_UPDATE_EMAIL", 1, tuple("client_id", "THE_CLIENT_ID"));
         PrometheusExporter.instance().recordGenericEvent(event1);
-        assertMetric("keycloak_user_event_UPDATE_EMAIL", 2);
+        assertMetric("keycloak_user_event_UPDATE_EMAIL", 2, tuple("client_id", "THE_CLIENT_ID"));
 
 
         final Event event2 = createEvent(EventType.REVOKE_GRANT);
         PrometheusExporter.instance().recordGenericEvent(event2);
-        assertMetric("keycloak_user_event_REVOKE_GRANT", 1);
-        assertMetric("keycloak_user_event_UPDATE_EMAIL", 2);
+        assertMetric("keycloak_user_event_REVOKE_GRANT", 1, tuple("client_id", "THE_CLIENT_ID"));
+        assertMetric("keycloak_user_event_UPDATE_EMAIL", 2, tuple("client_id", "THE_CLIENT_ID"));
     }
 
     @Test


### PR DESCRIPTION
## Motivation
Add label "client_id" to generic event counters.

## What
Add label "client_id" to generic event counters.

## Why
To separate metrics by client_id.

## How
Added label "client_id" to generic event counters.

## Verification Steps

1. Build the SPI from this branch and start Keycloak with it.
2. Login with users
3. Open the metrics endpoint in a browser.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

-
 

