### PR TITLE
Count users in keycloak_count_users metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,15 @@ This counter counts the number of response errors (responses where the http stat
 keycloak_response_errors{code="500",method="GET",} 1
 ```
 
+##### keycloak_count_users
+This gauge records the count of users.
+
+```c
+# HELP keycloak_count_users Count users
+# TYPE keycloak_count_users gauge
+keycloak_count_users{realm="test",} 1.0
+```
+
 ## Grafana Dashboard
 
 You can use this dashboard or create yours https://grafana.com/dashboards/10441

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListener.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListener.java
@@ -4,12 +4,22 @@ import org.jboss.logging.Logger;
 import org.keycloak.events.Event;
 import org.keycloak.events.EventListenerProvider;
 import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 
 public class MetricsEventListener implements EventListenerProvider {
 
     public final static String ID = "metrics-listener";
 
     private final static Logger logger = Logger.getLogger(MetricsEventListener.class);
+
+    private KeycloakSession session;
+
+    public MetricsEventListener (KeycloakSession session) {
+        this.session = session;
+    }
 
     @Override
     public void onEvent(Event event) {
@@ -21,6 +31,7 @@ public class MetricsEventListener implements EventListenerProvider {
                 break;
             case REGISTER:
                 PrometheusExporter.instance().recordRegistration(event);
+                countUsers(session.realms().getRealm(event.getRealmId()));
                 break;
             case REGISTER_ERROR:
                 PrometheusExporter.instance().recordRegistrationError(event);
@@ -37,7 +48,16 @@ public class MetricsEventListener implements EventListenerProvider {
     public void onEvent(AdminEvent event, boolean includeRepresentation) {
         logAdminEventDetails(event);
 
+        if (event.getResourceType() == ResourceType.USER && ( event.getOperationType() == OperationType.CREATE || event.getOperationType() == OperationType.DELETE)) {
+            countUsers(session.realms().getRealm(event.getRealmId()));
+        }
+
         PrometheusExporter.instance().recordGenericAdminEvent(event);
+    }
+
+    private void countUsers(RealmModel realm) {
+        int count = session.users().getUsersCount(realm);
+        PrometheusExporter.instance().recordCountUsers(realm.getId(), count);
     }
 
     private void logEventDetails(Event event) {

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListenerFactory.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListenerFactory.java
@@ -10,7 +10,7 @@ public class MetricsEventListenerFactory implements EventListenerProviderFactory
 
     @Override
     public EventListenerProvider create(KeycloakSession session) {
-        return new MetricsEventListener();
+        return new MetricsEventListener(session);
     }
 
     @Override

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -2,6 +2,7 @@ package org.jboss.aerogear.keycloak.metrics;
 
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
 import io.prometheus.client.exporter.PushGateway;
 import io.prometheus.client.exporter.common.TextFormat;
@@ -39,6 +40,7 @@ public final class PrometheusExporter {
     final Counter totalRegistrationsErrors;
     final Counter responseErrors;
     final Histogram requestDuration;
+    final Gauge countUsers;
     final PushGateway PUSH_GATEWAY;
 
     private PrometheusExporter() {
@@ -89,6 +91,12 @@ public final class PrometheusExporter {
             .help("Request duration")
             .buckets(50, 100, 250, 500, 1000, 2000, 10000, 30000)
             .labelNames("method")
+            .register();
+
+        countUsers = Gauge.build()
+            .name("keycloak_count_users")
+            .help("Count users")
+            .labelNames("realm")
             .register();
 
         // Counters for all user events
@@ -248,6 +256,17 @@ public final class PrometheusExporter {
             identityProvider = PROVIDER_KEYCLOAK_OPENID;
         }
         return identityProvider;
+    }
+
+    /**
+     * Set count of users 
+     *
+     * @param realmId The realm
+     * @param count Count users 
+     */
+    public void recordCountUsers(final String realmId, int count) {        
+        countUsers.labels(nullToEmpty(realmId)).set(count);
+        pushAsync();
     }
 
     /**

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -178,6 +178,12 @@ public class PrometheusExporterTest {
     }
 
     @Test
+    public void shouldCorrectlyRecordCountUsers() throws IOException {
+        PrometheusExporter.instance().recordCountUsers(DEFAULT_REALM, 5);
+        assertGenericMetric("keycloak_count_users", 5, tuple("realm", DEFAULT_REALM));
+    }
+
+    @Test
     public void shouldTolerateNullLabels() throws IOException {
         final Event nullEvent = new Event();
         nullEvent.setClientId(null);


### PR DESCRIPTION
## Motivation
Add a new metric which is a gauge of the total number of users on the Keycloak instance. https://github.com/aerogear/keycloak-metrics-spi/issues/81

## What
Add 1 Gauge :
- keycloak_count_users

## Why
Show the number of users

## How
On REGISTER or CREATE/DELETE User events, count the users of the realm.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Build the SPI from this branch and start Keycloak with it.
2. Register a new user
3. Add new user with admin-console
4. Open the metrics endpoint in a browser.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

I'm a newby with Prometheus metrics, so fell free to comment and propose better implementation.

Until first REGISTER or CREATE/DELETE User events, the metric is not set.