### PR TITLE
Update prometheusVersion to 0.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
 }
 
 group 'org.jboss.aerogear'
-version '2.0.2'
+version '2.0.2-SNAPSHOT'
 
 apply plugin: 'java'
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
 }
 
 group 'org.jboss.aerogear'
-version '2.0.2-SNAPSHOT'
+version '2.0.2'
 
 apply plugin: 'java'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 keycloakVersion=11.0.2
-prometheusVersion=0.3.0
+prometheusVersion=0.9.0


### PR DESCRIPTION
## Motivation
To use new version of push -gateway is necessary to update the simpleclient_pushgateway ,without this change
Keycloak get error on log with status code 200 instead 202

## What
Add new version 0.9.0 in  gradle.properties

## Why
The lib was old


