### PR TITLE
adding metric for total login attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ Every single internal Keycloak event is being shared through the endpoint, with 
 ### Featured events
 There are however a few events that are particularly more useful from a mobile app perspective. These events have been overriden by the SPI and are described more thoroughly below.
 
+##### keycloak_login_attempts
+
+This counter counts every login attempt performed by a non-admin user. It also distinguishes logins by the utilised
+identity provider by means of the label **provider** and by client with the label **client_id**..
+
+```c
+# HELP keycloak_login_attempts Total number of login attempts
+# TYPE keycloak_login_attempts counter
+keycloak_login_attempts{realm="test",provider="keycloak",client_id="account"} 3.0
+keycloak_login_attempts{realm="test",provider="github",client_id="application1"} 2.0
+```
+
 ##### keycloak_logins
 This counter counts every login performed by a non-admin user. It also distinguishes logins by the utilised identity provider by means of the label **provider** and by client with the label **client_id**..
 

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -34,6 +34,7 @@ public final class PrometheusExporter {
     // these fields are package private on purpose
     final Map<String, Counter> counters = new HashMap<>();
     final Counter totalLogins;
+    final Counter totalLoginAttempts;
     final Counter totalFailedLoginAttempts;
     final Counter totalRegistrations;
     final Counter totalRegistrationsErrors;
@@ -56,6 +57,13 @@ public final class PrometheusExporter {
         // sense to record the same metric in multiple places)
 
         PUSH_GATEWAY = buildPushGateWay();
+
+        // package private on purpose
+        totalLoginAttempts = Counter.build()
+            .name("keycloak_login_attempts")
+            .help("Total number of login attempts")
+            .labelNames("realm", "provider", "client_id")
+            .register();
 
         // package private on purpose
         totalLogins = Counter.build()
@@ -219,6 +227,7 @@ public final class PrometheusExporter {
     public void recordLogin(final Event event) {
         final String provider = getIdentityProvider(event);
 
+        totalLoginAttempts.labels(nullToEmpty(event.getRealmId()), provider, nullToEmpty(event.getClientId())).inc();
         totalLogins.labels(nullToEmpty(event.getRealmId()), provider, nullToEmpty(event.getClientId())).inc();
         pushAsync();
     }
@@ -255,6 +264,7 @@ public final class PrometheusExporter {
     public void recordLoginError(final Event event) {
         final String provider = getIdentityProvider(event);
 
+        totalLoginAttempts.labels(nullToEmpty(event.getRealmId()), provider, nullToEmpty(event.getClientId())).inc();
         totalFailedLoginAttempts.labels(nullToEmpty(event.getRealmId()), provider, nullToEmpty(event.getError()), nullToEmpty(event.getClientId())).inc();
         pushAsync();
     }

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -51,6 +51,21 @@ public class PrometheusExporterTest {
     }
 
     @Test
+    public void shouldCorrectlyCountLoginAttemptsForSuccessfulAndFailedAttempts() throws IOException {
+        // with LOGIN event
+        final Event login1 = createEvent(EventType.LOGIN, DEFAULT_REALM, "THE_CLIENT_ID");
+        PrometheusExporter.instance().recordLogin(login1);
+        assertMetric("keycloak_login_attempts", 1, tuple("provider", "keycloak"), tuple("client_id", "THE_CLIENT_ID"));
+        assertMetric("keycloak_logins", 1, tuple("provider", "keycloak"), tuple("client_id", "THE_CLIENT_ID"));
+
+        // with LOGIN_ERROR event
+        final Event event2 = createEvent(EventType.LOGIN_ERROR, DEFAULT_REALM, "THE_CLIENT_ID", "user_not_found");
+        PrometheusExporter.instance().recordLoginError(event2);
+        assertMetric("keycloak_login_attempts", 2, tuple("provider", "keycloak"), tuple("client_id", "THE_CLIENT_ID"));
+        assertMetric("keycloak_failed_login_attempts", 1, tuple("provider", "keycloak"), tuple("error", "user_not_found"), tuple("client_id", "THE_CLIENT_ID"));
+    }
+
+    @Test
     public void shouldCorrectlyCountLoginWhenIdentityProviderIsDefined() throws IOException {
         final Event login1 = createEvent(EventType.LOGIN, DEFAULT_REALM, "THE_CLIENT_ID", tuple("identity_provider", "THE_ID_PROVIDER"));
         PrometheusExporter.instance().recordLogin(login1);


### PR DESCRIPTION
## Motivation

issue: #92

this change adds a metric `keycloak_login_attempts` for the total 
number of login attempts. it might seem that it's possible to sum 
both `keycloak_logins` and `keycloak_failed_login_attempts` but as
the `totalLogins` and `totalFailedLoginAttempts` are counted 
separately their is now guarantee that both counters contain the
same metrics (labels with same values). in order to make it 
possible to calculate the failure rate per instance a new counter 
`totalLoginAttempts` is introduced.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Screenshot
![image](https://user-images.githubusercontent.com/30144822/103899501-c6a7e180-50f6-11eb-917c-0a5649a2bfc6.png)

 

