### PR TITLE
add an option to modify the 'instance' value with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ the metrics endpoint of each node. To fix this, you can push your metrics to a P
 You can enable pushing to PushGateway by setting the environment variable ```PROMETHEUS_PUSHGATEWAY_ADDRESS``` in the keycloak
 instance. The format is host:port or ip:port of the Pushgateway.
 
+The default value for the grouping key "instance" is the IP. This can be changed setting the environment variable ```PROMETHEUS_GROUPING_KEY_INSTANCE```
+to a fixed value. Additionaly, if the value provided starts with the prefix ```ENVVALUE:```,
+the string after the ```:``` will be used to get the value from the environment variable with that name.
+For example, with the next setting:
+```
+PROMETHEUS_GROUPING_KEY_INSTANCE=ENVVALUE:HOSTNAME
+```
+```instance``` will have the value of the environment variable ```HOSTNAME```
+
 ## Metrics
 
 For each metric, the endpoint returns 2 or more lines of information:


### PR DESCRIPTION
## Motivation
When deployed in kubernetes the IP is renewed with every restart. It would be great to have a way to specify the value for "instance" if necessary.

## What
Added a way to set the value of "instance" from environment variables.

## Why
Because we need to keep this value fixed in environments like kubernetes where the IP is renewed after restarts.

## How
Keeping the original behavior if the environment variable ```PROMETHEUS_GROUPING_KEY_INSTANCE``` is not set and using the value provided in that variable otherwise.

## Verification Steps
- Add the environment variable ```PROMETHEUS_GROUPING_KEY_INSTANCE=foo``` and verify that the instance value is "foo"
- Add the environment variable ```PROMETHEUS_GROUPING_KEY_INSTANCE=ENV:HOSTNAME``` and verify that the instance value is the value of ${HOSTNAME}

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

![Capture](https://user-images.githubusercontent.com/1216001/109644777-3ade8e80-7b56-11eb-8b50-c86dbf219850.PNG)


