### PR TITLE
MGDSTRM-1664 Resource support for latency metrics

### DIFF
--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -12,17 +12,20 @@ import org.keycloak.events.EventType;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.OperationType;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.net.URL;
-import java.net.MalformedURLException;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -146,14 +149,14 @@ public final class PrometheusExporter {
         responseErrors = Counter.build()
             .name("keycloak_response_errors")
             .help("Total number of error responses")
-            .labelNames("code", "method")
+            .labelNames("code", "method", "resource")
             .register();
 
         requestDuration = Histogram.build()
             .name("keycloak_request_duration")
             .help("Request duration")
             .buckets(50, 100, 250, 500, 1000, 2000, 10000, 30000)
-            .labelNames("method")
+            .labelNames("method", "resource")
             .register();
 
         // Counters for all user events
@@ -355,8 +358,8 @@ public final class PrometheusExporter {
      * @param amt    The duration in milliseconds
      * @param method HTTP method of the request
      */
-    public void recordRequestDuration(double amt, String method) {
-        requestDuration.labels(method).observe(amt);
+    public void recordRequestDuration(double amt, String method, String resource) {
+        requestDuration.labels(method, resource).observe(amt);
         pushAsync();
     }
 
@@ -366,8 +369,8 @@ public final class PrometheusExporter {
      * @param code   The returned http status code
      * @param method The request method used
      */
-    public void recordResponseError(int code, String method) {
-        responseErrors.labels(Integer.toString(code), method).inc();
+    public void recordResponseError(int code, String method, String resource) {
+        responseErrors.labels(Integer.toString(code), method, resource).inc();
         pushAsync();
     }
 

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
@@ -1,0 +1,57 @@
+package org.jboss.aerogear.keycloak.metrics;
+
+import org.jboss.logging.Logger;
+
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+
+class ResourceExtractor {
+
+    private final static Logger logger = Logger.getLogger(ResourceExtractor.class);
+
+    private static final boolean IS_RESOURCE_SCRAPING_DISABLED = Boolean.getBoolean("RESOURCE_SCRAPING_DISABLED");
+
+
+    private ResourceExtractor() {
+    }
+
+    /**
+     * This method obtains a list of resource info from the {@link UriInfo} object.
+     *
+     * The algorithm extracts the last two components for the {@link UriInfo#getMatchedURIs()} apart from the
+     * resources:
+     * 13:28:52,766 INFO  [stdout] (default task-2) Matched URIs: [resources/89pe1/admin/logo-example/partials/client-list.html, resources]
+     * 13:30:35,495 INFO  [stdout] (default task-3) Matched URIs: [realms/master/account, realms/master/account, realms]
+     * 13:32:53,160 INFO  [stdout] (default task-10) Matched URIs: [realms/master/.well-known/openid-configuration, realms]
+     * 13:33:16,656 INFO  [stdout] (default task-10) Matched URIs: [realms/master/protocol/openid-connect/auth, realms/master/protocol/openid-connect, realms]
+     * 13:33:47,319 INFO  [stdout] (default task-10) Matched URIs: [realms/master/protocol/openid-connect/certs, realms/master/protocol/openid-connect, realms]
+     * 13:34:37,768 INFO  [stdout] (default task-10) Matched URIs: [realms/master/account/applications, realms/master/account, realms]
+     * 13:35:48,003 INFO  [stdout] (default task-11) Matched URIs: [admin/realms/master/client-scopes/ee5e5908-a0b6-43c8-b213-fb452f129a5e, admin/realms/master/client-scopes, admin/realms/master, admin/realms, admin]
+     * 13:36:24,642 INFO  [stdout] (default task-11) Matched URIs: [admin/realms/master/users/171753bc-8184-4989-929b-288fdc661b90, admin/realms/master/users, admin/realms/master, admin/realms, admin]
+     * 13:36:24,793 INFO  [stdout] (default task-11) Matched URIs: [admin/realms/master/attack-detection/brute-force/users/171753bc-8184-4989-929b-288fdc661b90, admin/realms/master/attack-detection, admin/realms/master, admin/realms, admin]
+     *
+     * The mechanism might be switched off by using IS_RESOURCE_SCRAPING_DISABLED environment variable.
+     *
+     * @param uriInfo {@link UriInfo} object obtained from JAX-RS
+     * @return The resource name.
+     */
+    static String getResource(UriInfo uriInfo) {
+        if (!IS_RESOURCE_SCRAPING_DISABLED) {
+            List<String> matchedURIs = uriInfo.getMatchedURIs();
+            if (matchedURIs.size() >= 2) {
+                // A special case for all static resources - we're not interested in
+                // evey particular resource - just an aggregate with all other endpoints.
+                if ("resources".equals(matchedURIs.get(matchedURIs.size() - 1))) {
+                    return "";
+                }
+                StringBuilder sb = new StringBuilder();
+                sb.append(matchedURIs.get(matchedURIs.size() - 1));
+                sb.append(",");
+                sb.append(matchedURIs.get(matchedURIs.size() - 2));
+                return sb.toString();
+            }
+        }
+        return "";
+    }
+
+}

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -265,15 +265,18 @@ public class PrometheusExporterTest {
 
     @Test
     public void shouldCorrectlyRecordResponseDurations() throws IOException {
-        PrometheusExporter.instance().recordRequestDuration(5, "GET");
-        assertGenericMetric("keycloak_request_duration_count", 1, tuple("method", "GET"));
-        assertGenericMetric("keycloak_request_duration_sum", 5, tuple("method", "GET"));
+        PrometheusExporter.instance().recordRequestDuration(5, "GET", "admin,admin/serverinfo");
+        assertGenericMetric("keycloak_request_duration_count", 1,
+            tuple("method", "GET"), tuple("resource", "admin,admin/serverinfo"));
+        assertGenericMetric("keycloak_request_duration_sum", 5,
+            tuple("method", "GET"), tuple("resource", "admin,admin/serverinfo"));
     }
 
     @Test
     public void shouldCorrectlyRecordResponseErrors() throws IOException {
-        PrometheusExporter.instance().recordResponseError(500, "POST");
-        assertGenericMetric("keycloak_response_errors", 1, tuple("code", "500"), tuple("method", "POST"));
+        PrometheusExporter.instance().recordResponseError(500, "POST", "admin,admin/serverinfo");
+        assertGenericMetric("keycloak_response_errors", 1,
+            tuple("code", "500"), tuple("method", "POST"), tuple("resource", "admin,admin/serverinfo"));
     }
 
     @Test


### PR DESCRIPTION
## Motivation

https://issues.redhat.com/browse/MGDSTRM-1664

In order to support better observability, all the performance metrics need to support resources. This way, we know exactly which endpoints are fine and which cause some problems.

## What

This Pull Request introduces a new "resource" field into the latency metrics. Here's an example:

```
keycloak_request_duration_bucket{method="POST",resource="/protocol/openid-connect/token",le="50.0",} 1.0
keycloak_request_duration_bucket{method="POST",resource="/protocol/openid-connect/token",le="100.0",} 1.0
keycloak_request_duration_bucket{method="POST",resource="/protocol/openid-connect/token",le="250.0",} 2.0
keycloak_request_duration_bucket{method="POST",resource="/protocol/openid-connect/token",le="500.0",} 2.0
keycloak_request_duration_bucket{method="POST",resource="/protocol/openid-connect/token",le="1000.0",} 2.0
keycloak_request_duration_bucket{method="POST",resource="/protocol/openid-connect/token",le="2000.0",} 2.0
keycloak_request_duration_bucket{method="POST",resource="/protocol/openid-connect/token",le="10000.0",} 2.0
keycloak_request_duration_bucket{method="POST",resource="/protocol/openid-connect/token",le="30000.0",} 2.0
keycloak_request_duration_bucket{method="POST",resource="/protocol/openid-connect/token",le="+Inf",} 2.0
keycloak_request_duration_count{method="POST",resource="/protocol/openid-connect/token",} 2.0
keycloak_request_duration_sum{method="POST",resource="/protocol/openid-connect/token",} 122.0
keycloak_request_duration_bucket{method="GET",resource="/admin",le="50.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin",le="100.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin",le="250.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin",le="500.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin",le="1000.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin",le="2000.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin",le="10000.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin",le="30000.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin",le="+Inf",} 14.0
keycloak_request_duration_count{method="GET",resource="/admin",} 14.0
keycloak_request_duration_sum{method="GET",resource="/admin",} 39.0
keycloak_request_duration_bucket{method="POST",resource="/login-actions/authenticate",le="50.0",} 1.0
keycloak_request_duration_bucket{method="POST",resource="/login-actions/authenticate",le="100.0",} 1.0
keycloak_request_duration_bucket{method="POST",resource="/login-actions/authenticate",le="250.0",} 1.0
keycloak_request_duration_bucket{method="POST",resource="/login-actions/authenticate",le="500.0",} 1.0
keycloak_request_duration_bucket{method="POST",resource="/login-actions/authenticate",le="1000.0",} 1.0
keycloak_request_duration_bucket{method="POST",resource="/login-actions/authenticate",le="2000.0",} 1.0
keycloak_request_duration_bucket{method="POST",resource="/login-actions/authenticate",le="10000.0",} 1.0
keycloak_request_duration_bucket{method="POST",resource="/login-actions/authenticate",le="30000.0",} 1.0
keycloak_request_duration_bucket{method="POST",resource="/login-actions/authenticate",le="+Inf",} 1.0
keycloak_request_duration_count{method="POST",resource="/login-actions/authenticate",} 1.0
keycloak_request_duration_sum{method="POST",resource="/login-actions/authenticate",} 30.0
keycloak_request_duration_bucket{method="GET",resource="/admin/clients",le="50.0",} 13.0
keycloak_request_duration_bucket{method="GET",resource="/admin/clients",le="100.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin/clients",le="250.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin/clients",le="500.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin/clients",le="1000.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin/clients",le="2000.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin/clients",le="10000.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin/clients",le="30000.0",} 14.0
keycloak_request_duration_bucket{method="GET",resource="/admin/clients",le="+Inf",} 14.0
keycloak_request_duration_count{method="GET",resource="/admin/clients",} 14.0
keycloak_request_duration_sum{method="GET",resource="/admin/clients",} 136.0
keycloak_request_duration_bucket{method="GET",resource="",le="50.0",} 15.0
keycloak_request_duration_bucket{method="GET",resource="",le="100.0",} 15.0
keycloak_request_duration_bucket{method="GET",resource="",le="250.0",} 15.0
keycloak_request_duration_bucket{method="GET",resource="",le="500.0",} 15.0
keycloak_request_duration_bucket{method="GET",resource="",le="1000.0",} 15.0
keycloak_request_duration_bucket{method="GET",resource="",le="2000.0",} 15.0
keycloak_request_duration_bucket{method="GET",resource="",le="10000.0",} 15.0
keycloak_request_duration_bucket{method="GET",resource="",le="30000.0",} 15.0
keycloak_request_duration_bucket{method="GET",resource="",le="+Inf",} 15.0
keycloak_request_duration_count{method="GET",resource="",} 15.0
keycloak_request_duration_sum{method="GET",resource="",} 89.0
keycloak_request_duration_bucket{method="GET",resource="/protocol/openid-connect/auth",le="50.0",} 0.0
keycloak_request_duration_bucket{method="GET",resource="/protocol/openid-connect/auth",le="100.0",} 0.0
keycloak_request_duration_bucket{method="GET",resource="/protocol/openid-connect/auth",le="250.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/protocol/openid-connect/auth",le="500.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/protocol/openid-connect/auth",le="1000.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/protocol/openid-connect/auth",le="2000.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/protocol/openid-connect/auth",le="10000.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/protocol/openid-connect/auth",le="30000.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/protocol/openid-connect/auth",le="+Inf",} 2.0
keycloak_request_duration_count{method="GET",resource="/protocol/openid-connect/auth",} 2.0
keycloak_request_duration_sum{method="GET",resource="/protocol/openid-connect/auth",} 407.0
keycloak_request_duration_bucket{method="GET",resource="/admin/authentication",le="50.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/admin/authentication",le="100.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/admin/authentication",le="250.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/admin/authentication",le="500.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/admin/authentication",le="1000.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/admin/authentication",le="2000.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/admin/authentication",le="10000.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/admin/authentication",le="30000.0",} 2.0
keycloak_request_duration_bucket{method="GET",resource="/admin/authentication",le="+Inf",} 2.0
keycloak_request_duration_count{method="GET",resource="/admin/authentication",} 2.0
keycloak_request_duration_sum{method="GET",resource="/admin/authentication",} 5.0
```

## Why

This feature is require for better understanding the performance problems. 

## How

An additional "resource" field is added to the metrics.

## Verification Steps

1. Build the code
2. Copy the artifact into `$KC/standalone/deployments`
3. Make sure the metrics logger is turned on
4. Play with Keycloak a bit
5. Look at the following url: "$KC/auth/realms/master/metrics"

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task