### PR TITLE
Customize job name for multiple KeyCloak clusters on the same Prometheus PushGateway

### DIFF
--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -34,6 +34,8 @@ public final class PrometheusExporter {
 
     private final static String PROMETHEUS_PUSHGATEWAY_GROUPINGKEY_INSTANCE = "PROMETHEUS_GROUPING_KEY_INSTANCE";
     private final static Pattern PROMETHEUS_PUSHGATEWAY_GROUPINGKEY_INSTANCE_ENVVALUE_PATTERN = Pattern.compile("ENVVALUE:(.+?)");
+    
+    private final static String PROMETHEUS_PUSHGATEWAY_JOB = "PROMETHEUS_PUSHGATEWAY_JOB";
 
     private static PrometheusExporter INSTANCE;
 
@@ -446,8 +448,9 @@ public final class PrometheusExporter {
     private void push() {
         if(PUSH_GATEWAY != null) {
             try {
+                String job = Optional.ofNullable(System.getenv(PROMETHEUS_PUSHGATEWAY_JOB)).orElse("keycloak");
                 Map<String, String> groupingKey = Collections.singletonMap("instance", groupingKey());
-                PUSH_GATEWAY.pushAdd(CollectorRegistry.defaultRegistry, "keycloak", groupingKey);
+                PUSH_GATEWAY.pushAdd(CollectorRegistry.defaultRegistry, job, groupingKey);
             } catch (IOException e) {
                 logger.error("Unable to send to prometheus PushGateway", e);
             }


### PR DESCRIPTION
## Motivation
https://github.com/aerogear/keycloak-metrics-spi/issues/100

## What
This Pull Request introduces a new system environnment variable `PROMETHEUS_GROUPING_KEY_JOB ` to override default "keycloak" job name.

## Why
Being able to define our own custom `PROMETHEUS_GROUPING_KEY_JOB` in order to separate indicators of different clusters

## How
Add new system env `PROMETHEUS_GROUPING_KEY_JOB`

## Verification Steps
Add the steps required to check this change. Following an example.
 

1. Build the code
2. Copy the artifact into $KC/standalone/deployments
3. set system var env to PROMETHEUS_GROUPING_KEY_JOB=keycloak_cluster_A
3. Make sure the metrics logger is turned on
4. Play with Keycloak a bit
5. Look at the following url: "$KC/auth/realms/master/metrics", job name is equals to keycloak_cluster_A


## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
