### PR TITLE
added metric for number of total responses

### DIFF
--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilter.java
@@ -49,8 +49,7 @@ public final class MetricsFilter implements ContainerRequestFilter, ContainerRes
 
         String resource = ResourceExtractor.getResource(req.getUriInfo());
 
-        // We are only interested in recording the response status if it was an error
-        // (either a 4xx or 5xx). No point in counting  the successful responses
+        PrometheusExporter.instance().recordResponseTotal(status, req.getMethod(), resource);
         if (status >= 400) {
             PrometheusExporter.instance().recordResponseError(status, req.getMethod(), resource);
         }

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -55,6 +55,7 @@ public final class PrometheusExporter {
     final Counter totalFailedClientLoginAttempts;
     final Counter totalCodeToTokens;
     final Counter totalCodeToTokensErrors;
+    final Counter responseTotal;
     final Counter responseErrors;
     final Histogram requestDuration;
     final PushGateway PUSH_GATEWAY;
@@ -144,6 +145,12 @@ public final class PrometheusExporter {
             .name("keycloak_code_to_tokens_errors")
             .help("Total number of failed code to token")
             .labelNames("realm", "provider", "error", "client_id")
+            .register();
+
+        responseTotal = Counter.build()
+            .name("keycloak_response_total")
+            .help("Total number of responses")
+            .labelNames("code", "method", "resource")
             .register();
 
         responseErrors = Counter.build()
@@ -360,6 +367,17 @@ public final class PrometheusExporter {
      */
     public void recordRequestDuration(double amt, String method, String resource) {
         requestDuration.labels(method, resource).observe(amt);
+        pushAsync();
+    }
+
+    /**
+     * Increase the response total count by a given method and response code
+     *
+     * @param code   The returned http status code
+     * @param method The request method used
+     */
+    public void recordResponseTotal(int code, String method, String resource) {
+        responseTotal.labels(Integer.toString(code), method, resource).inc();
         pushAsync();
     }
 

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -273,6 +273,16 @@ public class PrometheusExporterTest {
     }
 
     @Test
+    public void shouldCorrectlyRecordResponseTotal() throws IOException {
+        PrometheusExporter.instance().recordResponseTotal(200, "GET", "admin,admin/serverinfo");
+        PrometheusExporter.instance().recordResponseTotal(500, "POST", "admin,admin/serverinfo");
+        assertGenericMetric("keycloak_response_total", 1,
+            tuple("code", "200"), tuple("method", "GET"), tuple("resource", "admin,admin/serverinfo"));
+        assertGenericMetric("keycloak_response_total", 1,
+            tuple("code", "500"), tuple("method", "POST"), tuple("resource", "admin,admin/serverinfo"));
+    }
+
+    @Test
     public void shouldCorrectlyRecordResponseErrors() throws IOException {
         PrometheusExporter.instance().recordResponseError(500, "POST", "admin,admin/serverinfo");
         assertGenericMetric("keycloak_response_errors", 1,


### PR DESCRIPTION
## Motivation

The ability to calculate the ratio of errors to total number of requests. see #90.

## What

This PR adds a new metric for reporting the total number of requests that where made in a addition to the number of failed requests.

## How

This was done similar to the number of failed requests.

## Verification Steps

A new metric `keycloak_response_total` should be reported. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
 

