### PR TITLE
MGDSTRM-2961 Adjust logging levels

### DIFF
--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListener.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEventListener.java
@@ -59,13 +59,13 @@ public class MetricsEventListener implements EventListenerProvider {
     }
 
     private void logEventDetails(Event event) {
-        logger.infof("Received user event of type %s in realm %s",
+        logger.debugf("Received user event of type %s in realm %s",
                 event.getType().name(),
                 event.getRealmId());
     }
 
     private void logAdminEventDetails(AdminEvent event) {
-        logger.infof("Received admin event of type %s (%s) in realm %s",
+        logger.debugf("Received admin event of type %s (%s) in realm %s",
                 event.getOperationType().name(),
                 event.getResourceType().name(),
                 event.getRealmId());


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/MGDSTRM-2961


## What
The metrics extension emits too much information and make debugging much harder.

