### PR TITLE
remove public access to metrics and updated uri metrics output

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,10 @@ keycloak_request_duration_count{code="200",method="GET",resource="admin,admin/se
 keycloak_request_duration_sum{code="200",method="GET",resource="admin,admin/serverinfo",uri="",} 19.0
 ```
 
+## External Access
+
+To disable metrics being externally accessible to a cluster. Set the environment variable 'DISABLE_EXTERNAL_ACCESS'. Once set enable the header 'X-Forwarded-Host' on your proxy. This is enabled by default on HA Proxy on Openshift.
+
 ## Grafana Dashboard
 
 You can use this dashboard or create yours https://grafana.com/dashboards/10441

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
+
+    compileOnly 'org.apache.tomcat:tomcat-servlet-api:9.0.37'
+
 }
 
 jar {

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpoint.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpoint.java
@@ -32,9 +32,8 @@ public class MetricsEndpoint implements RealmResourceProvider {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public Response get(@Context HttpHeaders headers) {
-
-        if (DISABLE_EXTERNAL_ACCESS){
-            if ( !headers.getRequestHeader("x-forwarded-host").isEmpty() ) {
+        if (DISABLE_EXTERNAL_ACCESS) {
+            if (!headers.getRequestHeader("x-forwarded-host").isEmpty()) {
                 // Request is being forwarded by HA Proxy on Openshift
                 return Response.status(Status.FORBIDDEN).build(); //(stream).build();
             }
@@ -47,18 +46,5 @@ public class MetricsEndpoint implements RealmResourceProvider {
     @Override
     public void close() {
         // Nothing to do, no resources to close
-    }
-
-        /**
-     * Write the Prometheus formatted values of all counters and
-     * gauges to the stream
-     *
-     * @param stream Output stream
-     * @throws IOException
-     */
-    public void export(final OutputStream stream) throws IOException {
-        final Writer writer = new BufferedWriter(new OutputStreamWriter(stream));
-        //TextFormat.write004(writer, CollectorRegistry.defaultRegistry.metricFamilySamples());
-        writer.flush();
     }
 }

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilter.java
@@ -7,15 +7,9 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.PathSegment;
-import javax.ws.rs.core.UriInfo;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public final class MetricsFilter implements ContainerRequestFilter, ContainerResponseFilter {
     private static final Logger LOG = Logger.getLogger(MetricsFilter.class);

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
@@ -13,13 +13,13 @@ class ResourceExtractor {
     private static final boolean URI_METRICS_ENABLED = Boolean.parseBoolean(System.getenv("URI_METRICS_ENABLED"));
     private static final boolean URI_METRICS_DETAILED = Boolean.parseBoolean(System.getenv("URI_METRICS_DETAILED"));
     private static final String URI_METRICS_FILTER = System.getenv("URI_METRICS_FILTER");
-    
+
     private ResourceExtractor() {
     }
 
     /**
      * This method obtains a list of resource info from the {@link UriInfo} object.
-     *
+     * <p>
      * The algorithm extracts the last two components for the {@link UriInfo#getMatchedURIs()} apart from the
      * resources:
      * 13:28:52,766 INFO  [stdout] (default task-2) Matched URIs: [resources/89pe1/admin/logo-example/partials/client-list.html, resources]
@@ -31,13 +31,13 @@ class ResourceExtractor {
      * 13:35:48,003 INFO  [stdout] (default task-11) Matched URIs: [admin/realms/master/client-scopes/ee5e5908-a0b6-43c8-b213-fb452f129a5e, admin/realms/master/client-scopes, admin/realms/master, admin/realms, admin]
      * 13:36:24,642 INFO  [stdout] (default task-11) Matched URIs: [admin/realms/master/users/171753bc-8184-4989-929b-288fdc661b90, admin/realms/master/users, admin/realms/master, admin/realms, admin]
      * 13:36:24,793 INFO  [stdout] (default task-11) Matched URIs: [admin/realms/master/attack-detection/brute-force/users/171753bc-8184-4989-929b-288fdc661b90, admin/realms/master/attack-detection, admin/realms/master, admin/realms, admin]
-     *
+     * <p>
      * The mechanism might be switched off by using IS_RESOURCE_SCRAPING_DISABLED environment variable.
      *
      * @param uriInfo {@link UriInfo} object obtained from JAX-RS
      * @return The resource name.
      */
-    static String getResource(UriInfo uriInfo) {        
+    static String getResource(UriInfo uriInfo) {
         if (!IS_RESOURCE_SCRAPING_DISABLED) {
             List<String> matchedURIs = uriInfo.getMatchedURIs();
             if (matchedURIs.size() >= 2) {
@@ -58,21 +58,21 @@ class ResourceExtractor {
 
     /**
      * This method obtains a list of resource info from the {@link UriInfo} object and returns the resource URI.
+     *
      * @param uriInfo {@link UriInfo} object obtained from JAX-RS
      * @return The resource uri.
      */
-    static String getURI(UriInfo uriInfo) {     
+    static String getURI(UriInfo uriInfo) {
         if (URI_METRICS_ENABLED) {
             List<String> matchedURIs = uriInfo.getMatchedURIs();
             StringBuilder sb = new StringBuilder();
 
-            if ( URI_METRICS_FILTER != null && URI_METRICS_FILTER.length() != 0 ){
+            if (URI_METRICS_FILTER != null && URI_METRICS_FILTER.length() != 0) {
 
                 String[] filter = URI_METRICS_FILTER.split(",");
 
-                for (int i = 0; i < filter.length; i++)
-                {
-                    if (matchedURIs.get(0).contains(filter[i])){
+                for (int i = 0; i < filter.length; i++) {
+                    if (matchedURIs.get(0).contains(filter[i])) {
 
                         sb = getURIDetailed(sb, matchedURIs);
                     }
@@ -80,31 +80,29 @@ class ResourceExtractor {
             } else {
                 sb = getURIDetailed(sb, matchedURIs);
             }
-            return sb.toString(); 
+            return sb.toString();
         }
         return "";
     }
 
-    private static StringBuilder getURIDetailed(StringBuilder sb, List<String> matchedURIs){
+    private static StringBuilder getURIDetailed(StringBuilder sb, List<String> matchedURIs) {
 
         String uri = matchedURIs.get(0);
 
-        if(URI_METRICS_DETAILED) {
+        if (URI_METRICS_DETAILED) {
             sb.append(uri);
         } else {
             String[] realm = uri.split("/");
-            if(realm.length != 1){
-                if(uri.startsWith("admin/realms/"))
-                {
-                    uri=uri.replace(realm[2], "{realm}");
-                    if(realm.length > 4 && realm[3].equals("clients")) {
-                        uri=uri.replace(realm[4], "{id}");
+            if (realm.length != 1) {
+                if (uri.startsWith("admin/realms/")) {
+                    uri = uri.replace(realm[2], "{realm}");
+                    if (realm.length > 4 && realm[3].equals("clients")) {
+                        uri = uri.replace(realm[4], "{id}");
                     }
 
                 }
-                if(uri.startsWith("realms/"))
-                {
-                    uri=uri.replace(realm[1], "{realm}");
+                if (uri.startsWith("realms/")) {
+                    uri = uri.replace(realm[1], "{realm}");
                 }
             }
             sb.append(uri);

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
@@ -68,7 +68,6 @@ class ResourceExtractor {
             StringBuilder sb = new StringBuilder();
 
             if (URI_METRICS_FILTER != null && URI_METRICS_FILTER.length() != 0) {
-
                 String[] filter = URI_METRICS_FILTER.split(",");
 
                 for (int i = 0; i < filter.length; i++) {
@@ -99,7 +98,6 @@ class ResourceExtractor {
                     if (realm.length > 4 && realm[3].equals("clients")) {
                         uri = uri.replace(realm[4], "{id}");
                     }
-
                 }
                 if (uri.startsWith("realms/")) {
                     uri = uri.replace(realm[1], "{realm}");

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
@@ -4,7 +4,6 @@ import org.jboss.logging.Logger;
 
 import javax.ws.rs.core.UriInfo;
 import java.util.List;
-import java.util.regex.*;
 
 class ResourceExtractor {
 
@@ -95,7 +94,18 @@ class ResourceExtractor {
         } else {
             String[] realm = uri.split("/");
             if(realm.length != 1){
-                uri=uri.replace(realm[1], "{realm}");
+                if(uri.startsWith("admin/realms/"))
+                {
+                    uri=uri.replace(realm[2], "{realm}");
+                    if(realm.length > 4 && realm[3].equals("clients")) {
+                        uri=uri.replace(realm[4], "{id}");
+                    }
+
+                }
+                if(uri.startsWith("realms/"))
+                {
+                    uri=uri.replace(realm[1], "{realm}");
+                }
             }
             sb.append(uri);
         }


### PR DESCRIPTION
## Motivation
Metrics are accessible outside of an openshift cluster, 
I've added a parameter to disable external access once the 'x-forwarded-host' header has data into as added by ha proxy on cluster. 

Updated metrics to replace client id with '{id}' when uri metrics are enabled and not detailed. 

