### PR TITLE
Make metrics-spi usable with Keycloak and Keycloak.X with 15.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Keycloak Metrics SPI
 
-A [Service Provider](https://www.keycloak.org/docs/4.8/server_development/index.html#_providers) that adds a metrics endpoint to Keycloak. The endpoint returns metrics data ready to be scraped by [Prometheus](https://prometheus.io/).
+A [Service Provider](https://www.keycloak.org/docs/latest/server_development/index.html#_providers) that adds a metrics endpoint to Keycloak. The endpoint returns metrics data ready to be scraped by [Prometheus](https://prometheus.io/).
 
 Two distinct providers are defined:
 
@@ -37,7 +37,7 @@ builds the jar and writes it to _build/libs_.
 You can build the project using a different version of Keycloak or Prometheus, running the command:
 
 ```sh
-$ ./gradlew -PkeycloakVersion="4.7.0.Final" -PprometheusVersion="0.3.0" jar
+$ ./gradlew -PkeycloakVersion="15.0.2.Final" -PprometheusVersion="0.12.0" jar
 ```
 
 or by changing the `gradle.properties` file in the root of the project.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-keycloakVersion=12.0.1
-prometheusVersion=0.9.0
+keycloakVersion=15.0.2
+prometheusVersion=0.12.0

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
@@ -20,14 +20,14 @@ public class MetricsEndpointFactory implements RealmResourceProviderFactory {
         String resteasyVersion = ResteasyProviderFactory.class.getPackage().getImplementationVersion();
         if (resteasyVersion.startsWith("3.")) {
             // This registers the MetricsFilter within environments that use Resteasy < 4.x, e.g. Keycloak on Wildfly / JBossEAP
-            registerResteasy3MetricsFilter();
+            registerMetricsFilterWithResteasy3();
         }
 
         // otherwise, we try to use the JAX-RS @Provider mechanism to register metrics filter
         // with Keycloak.X, see: MetricsFilterProvider
     }
 
-    private void registerResteasy3MetricsFilter() {
+    private void registerMetricsFilterWithResteasy3() {
 
         ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
         MetricsFilter filter = MetricsFilter.instance();

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
@@ -8,6 +8,7 @@ import org.keycloak.services.resource.RealmResourceProvider;
 import org.keycloak.services.resource.RealmResourceProviderFactory;
 
 public class MetricsEndpointFactory implements RealmResourceProviderFactory {
+
     @Override
     public RealmResourceProvider create(KeycloakSession session) {
         return new MetricsEndpoint();
@@ -15,11 +16,24 @@ public class MetricsEndpointFactory implements RealmResourceProviderFactory {
 
     @Override
     public void init(Config.Scope config) {
-        ResteasyProviderFactory.getInstance().getContainerRequestFilterRegistry()
-            .registerSingleton(MetricsFilter.instance());
 
-        ResteasyProviderFactory.getInstance().getContainerResponseFilterRegistry()
-            .registerSingleton(MetricsFilter.instance());
+        String resteasyVersion = ResteasyProviderFactory.class.getPackage().getImplementationVersion();
+        if (resteasyVersion.startsWith("3.")) {
+            // This registers the MetricsFilter within environments that use Resteasy < 4.x, e.g. Keycloak on Wildfly / JBossEAP
+            registerResteasy3MetricsFilter();
+        }
+
+        // otherwise, we try to use the JAX-RS @Provider mechanism to register metrics filter
+        // with Keycloak.X, see: MetricsFilterProvider
+    }
+
+    private void registerResteasy3MetricsFilter() {
+
+        ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
+        MetricsFilter filter = MetricsFilter.instance();
+
+        providerFactory.getContainerRequestFilterRegistry().registerSingleton(filter);
+        providerFactory.getContainerResponseFilterRegistry().registerSingleton(filter);
     }
 
     @Override

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilterProvider.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilterProvider.java
@@ -1,0 +1,24 @@
+package org.jboss.aerogear.keycloak.metrics;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * This provider registers the MetricsFilter within environments that use Resteasy 4.x and above, e.g. Keycloak.X.
+ */
+@Provider
+public class MetricsFilterProvider implements ContainerRequestFilter, ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        MetricsFilter.instance().filter(requestContext);
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        MetricsFilter.instance().filter(requestContext, responseContext);
+    }
+}


### PR DESCRIPTION
## Motivation

Currently the keycloak-metrics-spi does not work with Keycloak.X because
the `MetricsEndpointFactory` explicitly registers a `MetricsFilter` instance 
via the `ResteasyProviderFactory`, that uses Resteasy 3 API, which is not available 
in Keycloak.X.

## What
Add a workaround to be able to use keycloak-metrics-spi with Keycloak and Keycloak.X.

## Why
keycloak-metrics-spi did not work with Keycloak.X,

## How
This PR adds a guard around the `MetricsFilter` registration in the `MetricsEndpointFactory`,
which uses the Resteasy 3 API only if available.

To register the `MetricsFilter` in Keycloak.X environments, we use the JAX-RS providers 
support of of the Quarkus platform, which dynamically discovers and registers 
the `MetricsFilterProvider`, which delegates filter invocations to the `MetricsFilter` instance.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Build the .jar
2. Deploy the jar to Keycloak
3. Deploy the jar to Keycloak.X
4. Verify both servers can start and expose the metrics endpoint
5. Login to the Keycloak admin-console and inspect http://localhost:8080/realms/realms/master/metrics
6. Login to the Keycloak.X admin-console and inspect http://localhost:8080/realms/master/metrics

## Checklist
[x] Code has been tested locally by PR requester
[] Changes have been successfully verified by another team member

## Progress
[x] Finished task

## Additional Notes

Updated the keycloak version to 15.0.2
Updated the prometheus client version to 0.12.0
Fixed broken references in readme

Fixes https://github.com/aerogear/keycloak-metrics-spi/issues/107

