### PR TITLE
Added feature: UUID obfuscation in URI label with URI_METRICS_DETAILED enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,25 @@ keycloak_request_duration_count{code="200",method="GET",resource="admin,admin/se
 keycloak_request_duration_sum{code="200",method="GET",resource="admin,admin/serverinfo",uri="",} 19.0
 ```
 
+To replace `users` or `clients` UUID values by a generic `{id}` with ```URI_METRICS_DETAILED``` enabled,
+set ```URI_METRICS_UUID_HIDED``` to `true`
+
+```c
+# HELP keycloak_request_duration Request duration
+# TYPE keycloak_request_duration histogram
+keycloak_request_duration_bucket{code="200",method="GET",resource="admin,admin/realms",uri="admin/realms/master/users/{id}",le="50.0",} 6.0
+keycloak_request_duration_bucket{code="200",method="GET",resource="admin,admin/realms",uri="admin/realms/master/users/{id}",le="100.0",} 6.0
+keycloak_request_duration_bucket{code="200",method="GET",resource="admin,admin/realms",uri="admin/realms/master/users/{id}",le="250.0",} 6.0
+keycloak_request_duration_bucket{code="200",method="GET",resource="admin,admin/realms",uri="admin/realms/master/users/{id}",le="500.0",} 6.0
+keycloak_request_duration_bucket{code="200",method="GET",resource="admin,admin/realms",uri="admin/realms/master/users/{id}",le="1000.0",} 6.0
+keycloak_request_duration_bucket{code="200",method="GET",resource="admin,admin/realms",uri="admin/realms/master/users/{id}",le="2000.0",} 6.0
+keycloak_request_duration_bucket{code="200",method="GET",resource="admin,admin/realms",uri="admin/realms/master/users/{id}",le="10000.0",} 6.0
+keycloak_request_duration_bucket{code="200",method="GET",resource="admin,admin/realms",uri="admin/realms/master/users/{id}",le="30000.0",} 6.0
+keycloak_request_duration_bucket{code="200",method="GET",resource="admin,admin/realms",uri="admin/realms/master/users/{id}",le="+Inf",} 6.0
+keycloak_request_duration_count{code="200",method="GET",resource="admin,admin/realms",uri="admin/realms/master/users/{id}",} 6.0
+keycloak_request_duration_sum{code="200",method="GET",resource="admin,admin/realms",uri="admin/realms/master/users/{id}",} 41.0
+```
+
 ## External Access
 
 To disable metrics being externally accessible to a cluster. Set the environment variable 'DISABLE_EXTERNAL_ACCESS'. Once set enable the header 'X-Forwarded-Host' on your proxy. This is enabled by default on HA Proxy on Openshift.

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ keycloak_request_duration_sum{code="200",method="GET",resource="admin,admin/serv
 ```
 
 To replace `users` or `clients` UUID values by a generic `{id}` with ```URI_METRICS_DETAILED``` enabled,
-set ```URI_METRICS_UUID_HIDED``` to `true`
+set ```URI_METRICS_UUID_HIDDEN``` to `true`
 
 ```c
 # HELP keycloak_request_duration Request duration

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
@@ -91,10 +91,7 @@ class ResourceExtractor {
 
         if (URI_METRICS_DETAILED) {
             if (URI_METRICS_UUID_HIDDEN) {
-                String[] realm = uri.split("/");    
-                if (realm.length > 4 && (realm[3].equals("clients") || realm[3].equals("users"))) {
-                    uri = uri.replace(realm[4], "{id}");
-                }
+                uri = uri.replaceAll("\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}", "{id}");
                 sb.append(uri);
             } else {
                 sb.append(uri);

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
@@ -13,7 +13,7 @@ class ResourceExtractor {
     private static final boolean URI_METRICS_ENABLED = Boolean.parseBoolean(System.getenv("URI_METRICS_ENABLED"));
     private static final boolean URI_METRICS_DETAILED = Boolean.parseBoolean(System.getenv("URI_METRICS_DETAILED"));
     private static final String URI_METRICS_FILTER = System.getenv("URI_METRICS_FILTER");
-    private static final boolean URI_METRICS_UUID_HIDED = Boolean.parseBoolean(System.getenv("URI_METRICS_UUID_HIDED"));
+    private static final boolean URI_METRICS_UUID_HIDDEN = Boolean.parseBoolean(System.getenv("URI_METRICS_UUID_HIDDEN"));
 
     private ResourceExtractor() {
     }
@@ -90,7 +90,7 @@ class ResourceExtractor {
         String uri = matchedURIs.get(0);
 
         if (URI_METRICS_DETAILED) {
-            if (URI_METRICS_UUID_HIDED) {
+            if (URI_METRICS_UUID_HIDDEN) {
                 String[] realm = uri.split("/");    
                 if (realm.length > 4 && (realm[3].equals("clients") || realm[3].equals("users"))) {
                     uri = uri.replace(realm[4], "{id}");

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
@@ -13,6 +13,7 @@ class ResourceExtractor {
     private static final boolean URI_METRICS_ENABLED = Boolean.parseBoolean(System.getenv("URI_METRICS_ENABLED"));
     private static final boolean URI_METRICS_DETAILED = Boolean.parseBoolean(System.getenv("URI_METRICS_DETAILED"));
     private static final String URI_METRICS_FILTER = System.getenv("URI_METRICS_FILTER");
+    private static final boolean URI_METRICS_UUID_HIDED = Boolean.parseBoolean(System.getenv("URI_METRICS_UUID_HIDED"));
 
     private ResourceExtractor() {
     }
@@ -89,13 +90,21 @@ class ResourceExtractor {
         String uri = matchedURIs.get(0);
 
         if (URI_METRICS_DETAILED) {
-            sb.append(uri);
+            if (URI_METRICS_UUID_HIDED) {
+                String[] realm = uri.split("/");    
+                if (realm.length > 4 && (realm[3].equals("clients") || realm[3].equals("users"))) {
+                    uri = uri.replace(realm[4], "{id}");
+                }
+                sb.append(uri);
+            } else {
+                sb.append(uri);
+            }
         } else {
             String[] realm = uri.split("/");
             if (realm.length != 1) {
                 if (uri.startsWith("admin/realms/")) {
                     uri = uri.replace(realm[2], "{realm}");
-                    if (realm.length > 4 && realm[3].equals("clients")) {
+                    if (realm.length > 4 && (realm[3].equals("clients") || realm[3].equals("users"))) {
                         uri = uri.replace(realm[4], "{id}");
                     }
                 }


### PR DESCRIPTION
## Motivation
Monitor metrics per realms without constraint of high cardinality due to the presence of UUIDs in the URI label.

## What
Added the option to replace user's or client's UUID value in the URI label to a generic `{id}` value even when the _URI_METRICS_DETAILED_ system variable is set to `true`.

## Why
Needed to be able to monitor metrics with the realm name value present in the URI label but without UUIDs values, due to its high cardinality. The keycloak-metrics-spi evolution added the obfuscation of UUIDs only with the obfuscation of realm name value.

## How
By adding a check for a _URI_METRICS_UUID_HIDED_ system variable set to `true` & by adding "users" value to the condition of UUID obfuscation.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Additional Notes

Modified the README.md to add the description of this feature.

