### PR TITLE
Fix the dependency to work with Keycloak 16.0.0 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     bundleLib group: 'io.prometheus', name: 'simpleclient_pushgateway', version: prometheusVersion
     configurations.implementation.extendsFrom(configurations.bundleLib)
 
+    // Keycloak 16.0.0 comes with Wildfly 25 that brings RestEasy v4
+    implementation group: 'org.jboss.resteasy', name:'resteasy-multipart-provider', version: '4.7.3.Final'
+
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-keycloakVersion=12.0.1
+keycloakVersion=16.0.0
 prometheusVersion=0.9.0

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
@@ -15,11 +15,7 @@ public class MetricsEndpointFactory implements RealmResourceProviderFactory {
 
     @Override
     public void init(Config.Scope config) {
-        ResteasyProviderFactory.getInstance().getContainerRequestFilterRegistry()
-            .registerSingleton(MetricsFilter.instance());
-
-        ResteasyProviderFactory.getInstance().getContainerResponseFilterRegistry()
-            .registerSingleton(MetricsFilter.instance());
+        ResteasyProviderFactory.getInstance().register(MetricsFilter.instance());
     }
 
     @Override


### PR DESCRIPTION
## Motivation
Add references to relevant tickets or a short description about what motivated you do it. (E.g JIRA: https://issues.jboss.org/browse/AEROGEAR-{} AND/OR ISSUE: https://github.com/aerogear/standards/issues/{}) 
#124 

## What
Explicitly specify the RestEasy version that comes with Wildfly 25 instead of the one specified in Keycloak
Changed the method to register the Filter

## Why
RestEasy v4 has changed the API

## How
Explicit specification of the resteasy dependency on the build.gradle
Modified the way to register the filter

## Verification Steps
Already present tests are still working
Deployed Keycloak 16.0.0 with this new code and KC starts and the metrics endpoint responds with the metrics

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 

