### PR TITLE
Remove jcenter from Gradle repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,6 @@ plugins {
     id "net.nemerosa.versioning" version "2.8.2"
 }
 
-repositories {
-    jcenter()
-}
-
 configurations {
     bundleLib
 }


### PR DESCRIPTION
## Motivation
Since jcenter has beent shut down (see https://blog.gradle.org/jcenter-shutdown), the build fails for `./gradlew jar`.

## What
`jcenter()` has been removed from the `build.gradle` file. The default is `mavenCentral()`.

## Why
We at my company are building the .jar using Gradle. Since jcenter is the default repository, our builds failed.

## How
By removing the repositories block containing `jcenter()`.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Try `./gradlew jar`.
2. Should run successfully.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
