### PR TITLE
Remove jcenter repository block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,6 @@ plugins {
     id "net.nemerosa.versioning" version "2.8.2"
 }
 
-repositories {
-    jcenter()
-}
-
 configurations {
     bundleLib
 }


### PR DESCRIPTION
## Motivation
JCenter/Bintray has been down for a few days

## What
Removes the jcenter block from the dependencies

## Why
JCenter/Bintray was supposed to be shut down at an earlier point, but then announced it would remain "indefinitely" as a read-only mirror. Either they have decided that "indefinitely" is now over, or they are currently unable to restore operations to allow dependency downloads

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
