### PR TITLE
Add option to require bearer token authentication on the endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ The endpoint for the metrics is `<url>/<http_relative_path>/realms/<realm>/metri
 
 ### External Access
 
-By default, the metrics endpoint is accessible to **everyone** with access to your Keycloak instance.
+By default, the metrics endpoint returns HTTP Forbidden responses until authentication has been configured.
 
-Make sure to enable one of the following settings depending on your setup.
+To activate the metrics endpoint, one of the following settings depending on your setup must be enabled.
 
 #### Bearer Authentication
 
@@ -131,6 +131,15 @@ If using Bearer authentication is not an option, you can still protect the endpo
 Once set, requests in which the header 'X-Forwarded-Host' header is set will be denied.
 Thus, to disable access to the metrics the header must be set in a request on your proxy.
 This is enabled by default on HA Proxy on Openshift.
+
+#### Disable Authentication
+
+**NOT recommended**.
+
+If you are sure what you do and have considered the other authentication options, you can disable authentication completely.
+However, this will make your endpoint accessible to everyone with access to your Keycloak instance, if the metrics route is not otherwise protected.
+
+To disable the authentication, set the `KC_SPI_REALM_RESTAPI_EXTENSION_METRICS_AUTHENTICATION_DISABLED` environment variable (or corresponding command line argument) to `true`.
 
 ### Enable metrics-listener event
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,32 @@ ERROR: Failed to open /opt/keycloak/lib/../providers/keycloak-metrics-spi.jar
 ```
 The endpoint for the metrics is `<url>/<http_relative_path>/realms/<realm>/metrics`
 
+### External Access
+
+By default, the metrics endpoint is accessible to **everyone** with access to your Keycloak instance.
+
+Make sure to enable one of the following settings depending on your setup.
+
+#### Bearer Authentication
+
+Note: If you use Keycloak < 17 use the corresponding XML settings instead of the environment variables.
+
+You can enable protection of the metrics endpoint via Bearer authentication by setting the `KC_SPI_REALM_RESTAPI_EXTENSION_METRICS_BEARER_ENABLED` environment variable (or corresponding command line argument) to `true`.
+
+By default, the requesting user must be in the `master` realm and have the `prometheus-metrics` role.
+However, you can modify the realm using `KC_SPI_REALM_RESTAPI_EXTENSION_METRICS_REALM` and role using `KC_SPI_REALM_RESTAPI_EXTENSION_METRICS_ROLE`.
+
+To configure your Prometheus instance to obtain an OAuth2 token before querying the metrics endpoint, consult the [official Prometheus OAuth2 configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#oauth2).
+Use a client of type `confidential` that has `Service Accounts Enabled` set to `ON`.
+Then, make sure to include the role configured above in the `Service Account Roles` of that client.
+
+#### `DISABLE_EXTERNAL_ACCESS`
+
+If using Bearer authentication is not an option, you can still protect the endpoint using the `DISABLE_EXTERNAL_ACCESS` environment variable.
+Once set, requests in which the header 'X-Forwarded-Host' header is set will be denied.
+Thus, to disable access to the metrics the header must be set in a request on your proxy.
+This is enabled by default on HA Proxy on Openshift.
+
 ### Enable metrics-listener event
 
 - To enable the event listener via the GUI interface, go to _Manage -> Events -> Config_. The _Event Listeners_ configuration should have an entry named `metrics-listener`.
@@ -423,10 +449,6 @@ keycloak_request_duration_bucket{code="200",method="GET",resource="admin,admin/s
 keycloak_request_duration_count{code="200",method="GET",resource="admin,admin/serverinfo",uri="",} 1.0
 keycloak_request_duration_sum{code="200",method="GET",resource="admin,admin/serverinfo",uri="",} 19.0
 ```
-
-## External Access
-
-To disable metrics being externally accessible to a cluster. Set the environment variable 'DISABLE_EXTERNAL_ACCESS'. Once set enable the header 'X-Forwarded-Host' on your proxy. This is enabled by default on HA Proxy on Openshift.
 
 ## Grafana Dashboard
 

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpoint.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpoint.java
@@ -1,9 +1,17 @@
 package org.jboss.aerogear.keycloak.metrics;
 
+import org.jboss.logging.Logger;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.services.managers.AppAuthManager.BearerTokenAuthenticator;
+import org.keycloak.services.managers.AuthenticationManager.AuthResult;
 import org.keycloak.services.resource.RealmResourceProvider;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Produces;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Context;
@@ -24,6 +32,28 @@ public class MetricsEndpoint implements RealmResourceProvider {
 
     private static final boolean DISABLE_EXTERNAL_ACCESS = Boolean.parseBoolean(System.getenv("DISABLE_EXTERNAL_ACCESS"));
 
+    private final static Logger logger = Logger.getLogger(MetricsEndpoint.class);
+
+    private Boolean bearerEnabled;
+    private String role;
+    private AuthResult auth;
+
+    public MetricsEndpoint(KeycloakSession session, Boolean bearerEnabled, String realm, String role) {
+        super();
+
+        this.bearerEnabled = bearerEnabled;
+        if (this.bearerEnabled) {
+            RealmModel realmModel = session.realms().getRealmByName(realm);
+            if (realmModel == null) {
+                logger.errorf("Could not find realm with name %s", realm);
+                return;
+            }
+            session.getContext().setRealm(realmModel);
+            this.auth = new BearerTokenAuthenticator(session).authenticate();
+            this.role = role;
+        }
+    }
+
     @Override
     public Object getResource() {
         return this;
@@ -32,15 +62,27 @@ public class MetricsEndpoint implements RealmResourceProvider {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public Response get(@Context HttpHeaders headers) {
-        if (DISABLE_EXTERNAL_ACCESS) {
-            if (!headers.getRequestHeader("x-forwarded-host").isEmpty()) {
-                // Request is being forwarded by HA Proxy on Openshift
-                return Response.status(Status.FORBIDDEN).build(); //(stream).build();
-            }
-        }
+        checkAuthentication(headers);
 
         final StreamingOutput stream = output -> PrometheusExporter.instance().export(output);
         return Response.ok(stream).build();
+    }
+
+    private void checkAuthentication(HttpHeaders headers) {
+        if (DISABLE_EXTERNAL_ACCESS) {
+            if (!headers.getRequestHeader("x-forwarded-host").isEmpty()) {
+                // Request is being forwarded by HA Proxy on Openshift
+                throw new NotAuthorizedException("X-Forwarded-Host header is present");
+            }
+        }
+
+        if (this.bearerEnabled) {
+            if (this.auth == null) {
+                throw new NotAuthorizedException("Invalid bearer token");
+            } else if (this.auth.getToken().getRealmAccess() == null || !this.auth.getToken().getRealmAccess().isUserInRole(this.role)) {
+                throw new ForbiddenException("Missing required realm role");
+            }
+        }
     }
 
     @Override

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpoint.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpoint.java
@@ -34,13 +34,15 @@ public class MetricsEndpoint implements RealmResourceProvider {
 
     private final static Logger logger = Logger.getLogger(MetricsEndpoint.class);
 
+    private Boolean authenticationDisabled;
     private Boolean bearerEnabled;
     private String role;
     private AuthResult auth;
 
-    public MetricsEndpoint(KeycloakSession session, Boolean bearerEnabled, String realm, String role) {
+    public MetricsEndpoint(KeycloakSession session, Boolean authenticationDisabled, Boolean bearerEnabled, String realm, String role) {
         super();
 
+        this.authenticationDisabled = authenticationDisabled;
         this.bearerEnabled = bearerEnabled;
         if (this.bearerEnabled) {
             RealmModel realmModel = session.realms().getRealmByName(realm);
@@ -82,7 +84,15 @@ public class MetricsEndpoint implements RealmResourceProvider {
             } else if (this.auth.getToken().getRealmAccess() == null || !this.auth.getToken().getRealmAccess().isUserInRole(this.role)) {
                 throw new ForbiddenException("Missing required realm role");
             }
+            return;
         }
+
+        if (this.authenticationDisabled) {
+            return;
+        }
+
+        logger.error("Authentication on metrics endpoint is not configured!");
+        throw new ForbiddenException();
     }
 
     @Override

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
@@ -9,23 +9,26 @@ import org.keycloak.services.resource.RealmResourceProviderFactory;
 
 public class MetricsEndpointFactory implements RealmResourceProviderFactory {
 
+    private static final String DISABLE_AUTHENTICATION = "disableAuthentication";
     private static final String BEARER_ENABLED_CONFIGURATION = "bearerEnabled";
     private static final String REALM_CONFIGURATION = "realm";
     private static final String DEFAULT_REALM = "master";
     private static final String ROLE_CONFIGURATION = "role";
     private static final String DEFAULT_ROLE = "prometheus-metrics";
 
+    private Boolean authenticationDisabled;
     private Boolean bearerEnabled;
     private String realm;
     private String role;
 
     @Override
     public RealmResourceProvider create(KeycloakSession session) {
-        return new MetricsEndpoint(session, this.bearerEnabled, this.realm, this.role);
+        return new MetricsEndpoint(session, this.authenticationDisabled, this.bearerEnabled, this.realm, this.role);
     }
 
     @Override
     public void init(Config.Scope config) {
+        this.authenticationDisabled = config.getBoolean(DISABLE_AUTHENTICATION, false);
         this.bearerEnabled = config.getBoolean(BEARER_ENABLED_CONFIGURATION, false);
         this.realm = config.get(REALM_CONFIGURATION, DEFAULT_REALM);
         this.role = config.get(ROLE_CONFIGURATION, DEFAULT_ROLE);

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
@@ -9,13 +9,26 @@ import org.keycloak.services.resource.RealmResourceProviderFactory;
 
 public class MetricsEndpointFactory implements RealmResourceProviderFactory {
 
+    private static final String BEARER_ENABLED_CONFIGURATION = "bearerEnabled";
+    private static final String REALM_CONFIGURATION = "realm";
+    private static final String DEFAULT_REALM = "master";
+    private static final String ROLE_CONFIGURATION = "role";
+    private static final String DEFAULT_ROLE = "prometheus-metrics";
+
+    private Boolean bearerEnabled;
+    private String realm;
+    private String role;
+
     @Override
     public RealmResourceProvider create(KeycloakSession session) {
-        return new MetricsEndpoint();
+        return new MetricsEndpoint(session, this.bearerEnabled, this.realm, this.role);
     }
 
     @Override
     public void init(Config.Scope config) {
+        this.bearerEnabled = config.getBoolean(BEARER_ENABLED_CONFIGURATION, false);
+        this.realm = config.get(REALM_CONFIGURATION, DEFAULT_REALM);
+        this.role = config.get(ROLE_CONFIGURATION, DEFAULT_ROLE);
 
         String resteasyVersion = ResteasyProviderFactory.class.getPackage().getImplementationVersion();
         if (resteasyVersion.startsWith("3.")) {


### PR DESCRIPTION
## Motivation

The issues #39 and #119 regard authentication on the metrics endpoint.
While the configuration using the `path-prefix` WildFly configurations worked okayish, the new Quarkus distribution does not provide such a feature (as far as I know) leading to unprotected endpoints.

## What

Since Prometheus supports authentication using bearer token obtained via the OAuth 2 client credentials grant (see <https://prometheus.io/docs/prometheus/latest/configuration/configuration/#oauth2>), this PR adds exactly this protection option.

By enabling the `bearerEnabled` setting, authentication on the metrics endpoint using valid Bearer tokens can now be enforced. A client requesting the metrics endpoint must set the `Authorization: Bearer` header with a valid token obtained from Keycloak. The token must originate from the realm configured by the `realm` setting (defaults to `master`) and must have the role configured in the `role` setting (defaults to `prometheus-metrics`).

Furthermore, the second commit enforces that any of the authentication options is enabled, or, even though not recommended, authentication is explicitly disabled. Note that this is likely a breaking change.

## Why

The new Quarkus distribution is not an application server anymore and hence does not support protecting routes using the WildFly configuration.
Moreover, while this option worked okayish (some configurations still allowed access using workarounds such as URL encoding the word `metrics`), actual authentication using bearer tokens provides a more robust, integrated protection.

Furthermore, an authentication setting is enforced by default, as this should prevent users from accidentally exposing the metrics endpoint to the public.

## How

I added 4 new configuration options: `disableAuthentication`, `bearerEnabled`, `realm`, and `role`.

If bearer authentication is enabled, we use the integrated `AuthResult` from Keycloak and validate whether the requesting user (which can also be a client service account) is part of the required role.

## Verification Steps

I described the necessary configuration steps in the README in the `Bearer Authentication` section.
If those instructions are unclear or do not suffice, I'm happy to extend the guide.

You can also use a Bash script like the following to test the interaction manually without a running Prometheus instance (note that is requires `jq` to be installed).

```bash
#!/bin/bash

BASE="https://localhost:8443"
REALM="master"
CLIENT_ID="prometheus"
CLIENT_SECRET="<client-secret>"

token=$(curl --insecure -q -X POST "$BASE/auth/realms/$REALM/protocol/openid-connect/token" \
 -d 'grant_type=client_credentials' \
 -d "client_id=$CLIENT_ID" -d "client_secret=$CLIENT_SECRET" \
 | jq -r .access_token)

curl --insecure -vv -H "Authorization: Bearer $token" \
  "$BASE/auth/realms/$REALM/metrics"
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member