### PR TITLE
bump net.nemerosa.versioning to 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import java.text.SimpleDateFormat
 
 plugins {
-    id "net.nemerosa.versioning" version "2.8.2"
+    id "net.nemerosa.versioning" version "3.0.0"
 }
 
 repositories {


### PR DESCRIPTION
## Motivation
https://github.com/aerogear/keycloak-metrics-spi/issues/147

## What
Bump `net.nemerosa.versioning` to 3.0.0

## Why
Build stops working (see https://github.com/aerogear/keycloak-metrics-spi/issues/147)

## How
Bump `net.nemerosa.versioning` to 3.0.0

## Verification Steps
Run `./gradlew jar` command.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
 

