### PR TITLE
closes #155 make compatible with keycloak >= 21.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,11 +13,11 @@ configurations {
 }
 
 group 'org.jboss.aerogear'
-version '2.5.4-SNAPSHOT'
+version '3.0.0-SNAPSHOT'
 
 apply plugin: 'java'
 
-sourceCompatibility = 1.8
+sourceCompatibility = 17
 
 repositories {
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-keycloakVersion=15.0.2
-prometheusVersion=0.9.0
+keycloakVersion=21.0.1
+prometheusVersion=0.16.0

--- a/pom.xml
+++ b/pom.xml
@@ -7,15 +7,15 @@
     <artifactId>keycloak-metrics-spi</artifactId>
     <groupId>org.jboss.aerogear</groupId>
     <packaging>jar</packaging>
-    <version>2.5.3-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <properties>
-        <java.version>11</java.version>
-        <keycloak.version>15.0.2</keycloak.version>
-        <prometheus.version>0.9.0</prometheus.version>
+        <java.version>17</java.version>
+        <keycloak.version>21.0.1</keycloak.version>
+        <prometheus.version>0.16.0</prometheus.version>
         <version.compiler.maven.plugin>3.5.1</version.compiler.maven.plugin>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -152,7 +152,7 @@ public final class PrometheusExporter {
         final boolean URI_METRICS_ENABLED = Boolean.parseBoolean(System.getenv("URI_METRICS_ENABLED"));
         if (URI_METRICS_ENABLED){
             responseTotal = Counter.build()
-            .name("keycloak_response_total")
+            .name("keycloak_response")
             .help("Total number of responses")
             .labelNames("code", "method", "resource", "uri")
             .register();
@@ -171,7 +171,7 @@ public final class PrometheusExporter {
             .register();
         } else {
             responseTotal = Counter.build()
-            .name("keycloak_response_total")
+            .name("keycloak_response")
             .help("Total number of responses")
             .labelNames("code", "method", "resource")
             .register();

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -288,7 +288,7 @@ public class PrometheusExporterTest {
     public void shouldCorrectlyRecordResponseErrors() throws IOException {
         environmentVariables.set("URI_METRICS_ENABLED", "true");
         PrometheusExporter.instance().recordResponseError(500, "POST", "admin,admin/serverinfo", "auth/realm");
-        assertGenericMetric("keycloak_response_errors", 1,
+        assertGenericMetric("keycloak_response_errors_total", 1,
             tuple("code", "500"), tuple("method", "POST"), tuple("resource", "admin,admin/serverinfo"), tuple("uri", "auth/realm"));
     }
 
@@ -349,7 +349,7 @@ public class PrometheusExporterTest {
 
             final StringBuilder builder = new StringBuilder();
 
-            builder.append(metricName).append("{");
+            builder.append(metricName).append("_total").append("{");
             builder.append("realm").append("=\"").append(realm).append("\",");
 
             for (Tuple<String, String> label : labels) {


### PR DESCRIPTION
see naming conventions https://prometheus.io/docs/instrumenting/writing_exporters/#naming

The SPI seems to be incompatible with Keycloak >=21.0.0
This PR is switched to Java 17 and Keycloak 21.0 + Prometheus 0.16.0 compatibility

In this form it works on Keycloak 21.0.1 Quarkus on Java 17


## Motivation
Add references to relevant tickets or a short description about what motivated you do it. (E.g JIRA: 
https://issues.jboss.org/browse/AEROGEAR-{} AND/OR ISSUE: https://github.com/aerogear/standards/issues/{}) 

## What
Add an short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.)

## Why
Add an short answer for: Why it was done? (E.g The feature X was deprecated.)

## How
Add an short answer for: How it was done? (E.g By removing this feature from ... OR By removing just the button but not its implementation ... ) 

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 

