### PR TITLE
WIP: update java version in pom and fix mvn package failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <version>3.0.0-SNAPSHOT</version>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>11</java.version>
         <keycloak.version>21.0.1</keycloak.version>
         <prometheus.version>0.16.0</prometheus.version>
         <version.compiler.maven.plugin>3.5.1</version.compiler.maven.plugin>


### PR DESCRIPTION
Set the Java version in the pom back to 11. `mvn package` currently fails when running the tests. The same tests pass using Gradle though. I hope to fix this in this PR.