### PR TITLE
feat: move version in gradle.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ configurations {
 }
 
 group 'org.jboss.aerogear'
-version '3.0.1-SNAPSHOT'
 
 apply plugin: 'java'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 keycloakVersion=21.0.1
 prometheusVersion=0.16.0
+version=3.0.1-SNAPSHOT


### PR DESCRIPTION
## Motivation
Being able to set the version from the command lineduring build.

## What
Moving version in properties means it can be overwritten during the execution of gradle commands

## Why
See motivation

## How
Moving to gradle.properties are read before it reads the gradle.build file and can be overwritten from cli.

## Verification Steps
Build without the `-Pversion=3.0.0` and it build the one specified in the gradle.properties
Build with the `-Pversion=3.0.0` and will build the version specified in cli.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress
- [x] Finished task

## Additional Notes
N/A