### PR TITLE
feat: add support for reproducible builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ jar {
     manifest {
         attributes(
             'Built-By'       : System.properties['user.name'],
-            'Build-Timestamp': new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date()),
             'Build-Revision' : versioning.info.commit,
             'Created-By'     : "Gradle ${gradle.gradleVersion}",
             'Build-Jdk'      : "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
@@ -62,4 +61,9 @@ jar {
             'Version'        : "${gradle.rootProject.version}"
         )
     }
+}
+
+tasks.withType(AbstractArchiveTask.class).configureEach {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
 }


### PR DESCRIPTION
## Motivation
Add support for [reproducible] builds

## What
- Remove the timestamps from manifest 
- Remove timestamp from and archives
- Package in same order on archives

## Why
Reproducible builds [website](https://reproducible-builds.org/) explains this well.

## How
See What. Inspiration from gradle [docs]

## Verification Steps
 
1. Execute `gradle jar`
2. Rename jar into something different
3. Execute `gradle jar` again
4. Md5sum the two produced files, it should have the same hash.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes


[docs]: https://docs.gradle.org/current/userguide/working_with_files.html#sec:archives
[reproducible]: https://reproducible-builds.org/

