### PR TITLE
Updated KC dependency to 22.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <keycloak.version>21.0.1</keycloak.version>
+        <keycloak.version>22.0.0</keycloak.version>
         <prometheus.version>0.16.0</prometheus.version>
         <version.compiler.maven.plugin>3.5.1</version.compiler.maven.plugin>
         <maven.compiler.source>17</maven.compiler.source>
@@ -52,22 +52,28 @@
             <version>${keycloak.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
-            <version>1.0.0.Final</version>
-            <scope>provided</scope>
+        <dependency><!-- required by 'system-stubs-junit4' -->
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-junit4</artifactId>
+            <version>2.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.7.0</version>
+            <version>5.4.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>keycloak-metrics-spi</artifactId>
     <groupId>org.jboss.aerogear</groupId>
     <packaging>jar</packaging>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
 
     <properties>
         <java.version>17</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>keycloak-metrics-spi</artifactId>
     <groupId>org.jboss.aerogear</groupId>
     <packaging>jar</packaging>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
 
     <properties>
         <java.version>17</java.version>

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpoint.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpoint.java
@@ -2,8 +2,12 @@ package org.jboss.aerogear.keycloak.metrics;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.*;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.StreamingOutput;
 import org.keycloak.services.resource.RealmResourceProvider;
 
 public class MetricsEndpoint implements RealmResourceProvider {

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpoint.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpoint.java
@@ -1,21 +1,10 @@
 package org.jboss.aerogear.keycloak.metrics;
 
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.*;
+import jakarta.ws.rs.core.Response.Status;
 import org.keycloak.services.resource.RealmResourceProvider;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.StreamingOutput;
-import javax.ws.rs.core.Response.Status;
-
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
 
 public class MetricsEndpoint implements RealmResourceProvider {
 

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilter.java
@@ -1,12 +1,12 @@
 package org.jboss.aerogear.keycloak.metrics;
 
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.MediaType;
 import org.jboss.logging.Logger;
 
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.core.MediaType;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilterProvider.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilterProvider.java
@@ -1,10 +1,10 @@
 package org.jboss.aerogear.keycloak.metrics;
 
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
 
 /**
  * This provider registers the MetricsFilter within environments that use Resteasy 4.x and above, e.g. Keycloak.X.

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
@@ -1,8 +1,8 @@
 package org.jboss.aerogear.keycloak.metrics;
 
+import jakarta.ws.rs.core.UriInfo;
 import org.jboss.logging.Logger;
 
-import javax.ws.rs.core.UriInfo;
 import java.util.List;
 
 class ResourceExtractor {

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -6,7 +6,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.keycloak.events.Event;
 import org.keycloak.events.EventType;
 import org.keycloak.events.admin.AdminEvent;
@@ -14,6 +13,7 @@ import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RealmProvider;
+import uk.org.webcompere.systemstubs.rules.EnvironmentVariablesRule;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -44,7 +44,7 @@ public class PrometheusExporterTest {
     }
 
     @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    public final EnvironmentVariablesRule environmentVariables = new EnvironmentVariablesRule();
 
     @Before
     public void resetSingleton() throws SecurityException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {


### PR DESCRIPTION
For compatibility with KC22: replaced Java EE with Jakarta EE.
Test: replaced obsolete 'com.github.stefanbirker:system-rules' dependency with a similar library 'uk.org.webcompere:system-stubs-junit4'.

Note: this change might NOT be compatible with KC < 22.x !

## Motivation
Metrics not compatible with Keycloak 22 due to change from Java EE to Jakarta EE.
https://github.com/aerogear/keycloak-metrics-spi/issues/168

## What
Replaces Java EE imports with Jakarta EE imports. No further code changes.

## Why
Keycloak 22 replaced Java EE with Jakarta EE making this library not compatible anymore, throwing a ClassNotFoundException at startup.

## How
Replaces Java EE imports with Jakarta EE imports. No further code changes.

For test had to replace the old (and obsolete?) `system-rules` dependency with a more current version by `uk.org.compere` due to module issues since Keycloak 22 now also is just for Java 17 (Java 11 compatibility was dropped).
```
 PrometheusExporterTest.shouldBuildPushgateway » InaccessibleObject Unable to make field private final java.util.Map java.util.Collections$UnmodifiableMap.m accessible: module java.base does not "opens java.util" to unnamed module @70beb599
```
Updating the dependency fixed this issue.

## Verification Steps

1. Add this version to KC 22 install
2. Start KC 22
3. Login to KC 22
4. Enable 'metrics-listener' to realm events settings
5. Logout en login to KC to trigger event to send to metrics listener
6. Verify metics on /auth/realms/master/metrics endpoint

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] build library with fix
- [x] deployed fix to local repository
- [x] build KC22 container with fixed metrics api
- [x] deployed KC22 contain on Kubernetes
- [x] verified Prometheus target on /auth/realms/master/metrics is 'Up'
- [x] verified Keycloak dashboard displays realm metrics again 
- [ ] Merge PR and build new version
- [ ] Replace snapshot dependency with released dependency

## Additional Notes

Due to the changes in KC 22 (dropped Java 11 compatibility, change from Java EE to Jakarta EE), these changes are likely not compatible with KC versions < 22.x.
 

