### PR TITLE
Add optional basic auth for pushgateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ the metrics endpoint of each node. To fix this, you can push your metrics to a P
 You can enable pushing to PushGateway by setting the environment variable ```PROMETHEUS_PUSHGATEWAY_ADDRESS``` in the keycloak
 instance. The format is host:port or ip:port of the Pushgateway.
 
+If you need basic authentication you must set `PROMETHEUS_PUSHGATEWAY_BASIC_AUTH_USERNAME` and `PROMETHEUS_PUSHGATEWAY_BASIC_AUTH_PASSWORD`.
+
 #### **Grouping instances**
 The default value for the grouping key "instance" is the IP. This can be changed setting the environment variable ```PROMETHEUS_GROUPING_KEY_INSTANCE```
 to a fixed value. Additionaly, if the value provided starts with the prefix ```ENVVALUE:```,

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -3,6 +3,7 @@ package org.jboss.aerogear.keycloak.metrics;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Histogram;
+import io.prometheus.client.exporter.BasicAuthHttpConnectionFactory;
 import io.prometheus.client.exporter.PushGateway;
 import io.prometheus.client.exporter.common.TextFormat;
 import io.prometheus.client.hotspot.DefaultExports;
@@ -530,6 +531,12 @@ public final class PrometheusExporter {
                 logger.info("Pushgateway created with url " + host + ".");
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
+            }
+            String basic_auth_username = System.getenv("PROMETHEUS_PUSHGATEWAY_BASIC_AUTH_USERNAME");
+            String basic_auth_password = System.getenv("PROMETHEUS_PUSHGATEWAY_BASIC_AUTH_PASSWORD");
+            if (basic_auth_username != null && basic_auth_password != null) {
+                logger.info("Enabled basic auth for pushgateway.");
+                pg.setConnectionFactory(new BasicAuthHttpConnectionFactory(basic_auth_username, basic_auth_password));
             }
         }
         return pg;

--- a/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
+++ b/src/test/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporterTest.java
@@ -327,6 +327,20 @@ public class PrometheusExporterTest {
     }
 
     @Test
+    public void shouldBuildPushgatewayWithBasicAuth() throws IOException {
+        final String envVarAddress = "PROMETHEUS_PUSHGATEWAY_ADDRESS";
+        final String address = "localhost:9091";
+        environmentVariables.set(envVarAddress, address);
+        final String envVarUser = "PROMETHEUS_PUSHGATEWAY_BASIC_AUTH_USERNAME";
+        final String user = "username";
+        environmentVariables.set(envVarUser, user);
+        final String envVarPassword = "PROMETHEUS_PUSHGATEWAY_BASIC_AUTH_PASSWORD";
+        final String password = "password";
+        environmentVariables.set(envVarPassword, password);
+        Assert.assertNotNull(PrometheusExporter.instance().PUSH_GATEWAY);
+    }
+
+    @Test
     public void shouldBuildPushgatewayWithHttps() throws IOException {
         final String envVar = "PROMETHEUS_PUSHGATEWAY_ADDRESS";
         final String address = "https://localhost:9091";


### PR DESCRIPTION
## Motivation
Resolves #145.

## What
Allow users to provide username and password for basic auth protected pushgateways.

## Why
Some pushgateways may require basic auth authentification.

## How
https://github.com/prometheus/client_java/blob/main/integration_tests/it_pushgateway/src/main/java/io/prometheus/client/it/pushgateway/ExampleBatchJob.java#L32C13-L32C91

## Verification Steps
A simple test has been added.

To test this completely:
* Protect a pushgateway endpoint using basic auth
* Set the required env variables
* Start keycloak and verify metrics in pushgateway

## Checklist:
- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

