### PR TITLE
Fix Gradle build for v4.0.0 and Keycloak 22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,15 +33,16 @@ dependencies {
     implementation group: 'org.keycloak', name: 'keycloak-server-spi-private', version: keycloakVersion
     implementation group: 'org.keycloak', name: 'keycloak-server-spi', version: keycloakVersion
     implementation group: 'org.keycloak', name: 'keycloak-services', version: keycloakVersion
-    implementation group: 'org.jboss.spec.javax.ws.rs', name: 'jboss-jaxrs-api_2.0_spec', version: '1.0.0.Final'
     bundleLib group: 'io.prometheus', name: 'simpleclient_common', version: prometheusVersion
     bundleLib group: 'io.prometheus', name: 'simpleclient_hotspot', version: prometheusVersion
     bundleLib group: 'io.prometheus', name: 'simpleclient_pushgateway', version: prometheusVersion
     configurations.implementation.extendsFrom(configurations.bundleLib)
 
-    testImplementation group: 'junit', name: 'junit', version: '4.12'
-    testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.7.0'
+    testImplementation group: 'junit', name: 'junit', version: '4.13'
+    testImplementation group: 'uk.org.webcompere', name: 'system-stubs-junit4', version: '2.0.2'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.4.0'
+    // required by 'system-stubs-junit4'
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
 
     compileOnly 'org.apache.tomcat:tomcat-servlet-api:9.0.37'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-keycloakVersion=21.0.1
+keycloakVersion=22.0.0
 prometheusVersion=0.16.0


### PR DESCRIPTION
## Motivation

The Gradle build is broken (see https://github.com/aerogear/keycloak-metrics-spi/issues/173#issuecomment-1669779136).

## Why

The 4.0.0 release contains an update to Keycloak 22 introduced in #169 .
While this adjusted the dependencies in the pom.xml for the Maven build, it did not adjust the build.gradle file.
This lead to `./gradlew jar` failing.

## How

We have now adjusted the build.gradle to reflect the same dependency changes that have been made to the pom.xml.
With that, we also bump the Keycloak version in the gradle.properties to 22.

## Verification Steps

1. Build with `./gradlew jar`

Alternatively, use the Dockerfile from #173 for a clean environment:

```Dockerfile
FROM gradle:7.4.2-jdk17 AS metrics
WORKDIR /spi
USER root
RUN chown -R gradle /spi
USER gradle
RUN git clone https://github.com/aerogear/keycloak-metrics-spi.git . \
        && ./gradlew jar
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 