### PR TITLE
Add quarkus-resteasy-reactive dependency to build gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
 
     compileOnly 'org.apache.tomcat:tomcat-servlet-api:9.0.37'
+    compileOnly 'io.quarkus:quarkus-resteasy-reactive:3.2.9.Final'
 
 }
 


### PR DESCRIPTION
## Motivation
While the build works with maven (and the dependency was added with aede7e08) it currently fails with gradle:

```
./gradlew clean build
..
src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsFilterProvider.java:18: error: cannot find symbol
..
```

## What
Adds the `quarkus-resteasy-reactive` to the `build.gradle`.

## Why
Build was unable to complete successfully.

## How
Adding to `build.gradle`.

## Verification Steps
1. ./gradlew clean build

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task


 

