### PR TITLE
Fix resteasy missing in gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
 
     compileOnly 'org.apache.tomcat:tomcat-servlet-api:9.0.37'
+    compileOnly 'io.quarkus:quarkus-resteasy-reactive:3.2.9.Final'
 
 }
 


### PR DESCRIPTION
## Motivation
The compilation failed when using gradle

## What
Replay the changes introduced in #184 for gradle

## Why
Project could not be built with gradle due to missing dependencies.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Additional Notes

Would it make sense to introduce GH Actions which build using both maven and gradle or just drop support for one of them, as this apparently happened before. 

