### PR TITLE
Keycloak 25 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Two distinct providers are defined:
 * MetricsEventListener to record the internal Keycloak events
 * MetricsEndpoint to expose the data through a custom endpoint
 
-The endpoint is available under `<base url>/realms/<realm>/metrics` (Quarkus) or `<base url>/auth/realms/<realm>/metrics` (Wildfly). 
+The endpoint is available under `<base url>/realms/<realm>/metrics` (Quarkus). 
 It will return data for all realms, no matter which realm you use in the URL.
 
 ## License 
@@ -69,20 +69,6 @@ mvn clean package -Dkeycloak.version=15.0.0 -Dprometheus.version=0.9.0
 ```
 
 ## Install and setup
-
-### On Keycloak Widfly Distribution
-> This section assumes `/opt/jboss` as the Keycloak home directory, which is used on the _jboss/keycloak_ reference container on Docker Hub.
-
-- Drop the [jar](https://github.com/aerogear/keycloak-metrics-spi/releases/latest) into the _/opt/jboss/keycloak/standalone/deployments/_ subdirectory of your Keycloak installation.
-
-- Touch a dodeploy file into the _/opt/jboss/keycloak/standalone/deployments/_ subdirectory of your Keycloak installation.
-
-```bash
-# If your jar file is `keycloak-metrics-spi-2.0.2.jar`
-cd /opt/jboss/keycloak/standalone/deployments/
-touch keycloak-metrics-spi-2.0.2.jar.dodeploy
-```
-- Restart the keycloak service.
 
 ### On Keycloak Quarkus Distribution
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 ext {
     keycloakVersion=project.properties["keycloakVersion"]
+    quarkusResteasyVersion=project.properties["quarkusResteasyVersion"]
     prometheusVersion=project.properties["prometheusVersion"]
 }
 
@@ -33,6 +34,7 @@ dependencies {
     implementation group: 'org.keycloak', name: 'keycloak-server-spi-private', version: keycloakVersion
     implementation group: 'org.keycloak', name: 'keycloak-server-spi', version: keycloakVersion
     implementation group: 'org.keycloak', name: 'keycloak-services', version: keycloakVersion
+    compileOnly group: 'io.quarkus.resteasy.reactive', name: 'resteasy-reactive', version: quarkusResteasyVersion
     bundleLib group: 'io.prometheus', name: 'simpleclient_common', version: prometheusVersion
     bundleLib group: 'io.prometheus', name: 'simpleclient_hotspot', version: prometheusVersion
     bundleLib group: 'io.prometheus', name: 'simpleclient_pushgateway', version: prometheusVersion

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,7 @@ import java.text.SimpleDateFormat
 
 plugins {
     id "net.nemerosa.versioning" version "3.0.0"
-}
-
-repositories {
-    jcenter()
+    id "java"
 }
 
 configurations {
@@ -15,9 +12,10 @@ configurations {
 group 'org.jboss.aerogear'
 version '5.0.1-SNAPSHOT'
 
-apply plugin: 'java'
 
-sourceCompatibility = 11
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+}
 
 repositories {
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
-keycloakVersion=23.0.3
+keycloakVersion=25.0.0
 prometheusVersion=0.16.0
+quarkusResteasyVersion=3.8.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
     <version>5.0.1-SNAPSHOT</version>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <keycloak.version>25.0.0</keycloak.version>
         <prometheus.version>0.16.0</prometheus.version>
         <quarkus-resteasy.version>3.8.5</quarkus-resteasy.version>
         <version.compiler.maven.plugin>3.5.1</version.compiler.maven.plugin>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
 
     <properties>
         <java.version>17</java.version>
-        <keycloak.version>23.0.3</keycloak.version>
+        <keycloak.version>25.0.0</keycloak.version>
         <prometheus.version>0.16.0</prometheus.version>
-        <quarkus-resteasy.version>3.2.9.Final</quarkus-resteasy.version>
+        <quarkus-resteasy.version>3.8.5</quarkus-resteasy.version>
         <version.compiler.maven.plugin>3.5.1</version.compiler.maven.plugin>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -54,8 +54,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive</artifactId>
+            <groupId>io.quarkus.resteasy.reactive</groupId>
+            <artifactId>resteasy-reactive</artifactId>
             <version>${quarkus-resteasy.version}</version>
             <scope>provided</scope>
         </dependency>        

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/MetricsEndpointFactory.java
@@ -1,6 +1,5 @@
 package org.jboss.aerogear.keycloak.metrics;
 
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
@@ -16,24 +15,7 @@ public class MetricsEndpointFactory implements RealmResourceProviderFactory {
 
     @Override
     public void init(Config.Scope config) {
-
-        String resteasyVersion = ResteasyProviderFactory.class.getPackage().getImplementationVersion();
-        if (resteasyVersion.startsWith("3.")) {
-            // This registers the MetricsFilter within environments that use Resteasy < 4.x, e.g. Keycloak on Wildfly / JBossEAP
-            registerMetricsFilterWithResteasy3();
-        }
-
-        // otherwise, we try to use the JAX-RS @Provider mechanism to register metrics filter
-        // with Keycloak.X, see: MetricsFilterProvider
-    }
-
-    private void registerMetricsFilterWithResteasy3() {
-
-        ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
-        MetricsFilter filter = MetricsFilter.instance();
-
-        providerFactory.getContainerRequestFilterRegistry().registerSingleton(filter);
-        providerFactory.getContainerResponseFilterRegistry().registerSingleton(filter);
+        // nothing to do
     }
 
     @Override


### PR DESCRIPTION
## Motivation
I want to use the metrics spi with the newest keycloak version.


Releated issue: https://github.com/aerogear/keycloak-metrics-spi/issues/199

## What
Migrating to compatible  RESTEasy Reactive dependencies.

## Why
The current implementation is incompatible with Keycloak 25 due to the complete transition to RESTEasy Reactive. See issue: https://github.com/keycloak/keycloak/issues/29223.

## How
Both the Maven `pom.xml` and the `build.gradle` files have been updated to reflect the new dependencies. Additionally, support for WildFly JBoss has been removed because the code could not be easily migrated to the reactive dependencies. Moreover, I do not see a necessity for maintaining WildFly support: https://www.keycloak.org/migration/migrating-to-quarkus.

- changed dependency to io.quarkus.resteasy.reactive:resteasy-reactive
- updated to quarkus-resteasy version to 3.8.5
- removed filter for deprecated and incompatible Wildfly / JBossEAP

## Verification Steps
1. run `mvn compile` or `./gradlew build` to verify

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes
