### PR TITLE
Aerogear 10382 fix failing gradle build in 5.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 
 ext {
     keycloakVersion=project.properties["keycloakVersion"]
+    quarkusResteasyVersion=project.properties["quarkusResteasyVersion"]
     prometheusVersion=project.properties["prometheusVersion"]
 }
 
@@ -29,6 +30,7 @@ dependencies {
     implementation group: 'org.keycloak', name: 'keycloak-server-spi-private', version: keycloakVersion
     implementation group: 'org.keycloak', name: 'keycloak-server-spi', version: keycloakVersion
     implementation group: 'org.keycloak', name: 'keycloak-services', version: keycloakVersion
+    compileOnly group: 'io.quarkus.resteasy.reactive', name: 'resteasy-reactive', version: quarkusResteasyVersion
     bundleLib group: 'io.prometheus', name: 'simpleclient_common', version: prometheusVersion
     bundleLib group: 'io.prometheus', name: 'simpleclient_hotspot', version: prometheusVersion
     bundleLib group: 'io.prometheus', name: 'simpleclient_pushgateway', version: prometheusVersion

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,6 @@ plugins {
     id "net.nemerosa.versioning" version "3.0.0"
 }
 
-repositories {
-    jcenter()
-}
-
 configurations {
     bundleLib
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 keycloakVersion=23.0.3
 prometheusVersion=0.16.0
+quarkusResteasyVersion=3.2.9.Final


### PR DESCRIPTION
## Motivation
Fix for JIRA Ticket https://issues.redhat.com/browse/AEROGEAR-10382 and also #189 and #201 issues on github.

## What
In version 5.0.0, the gradle build is failing.

## Why
the jcenter repo is not reachable anymore and there is a missing dependency "resteasy"

## How
I removed the repo and added the missing dependency, analog to the fix in version 6.0.0

## Verification Steps
1. run gradle build
2. check if build succeeds

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 

