### PR TITLE
Build against Keycloak 26.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-keycloakVersion=25.0.0
+keycloakVersion=26.0.0
 prometheusVersion=0.16.0
 quarkusResteasyVersion=3.8.5

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <keycloak.version>25.0.0</keycloak.version>
+        <keycloak.version>26.0.0</keycloak.version>
         <prometheus.version>0.16.0</prometheus.version>
         <quarkus-resteasy.version>3.8.5</quarkus-resteasy.version>
         <version.compiler.maven.plugin>3.5.1</version.compiler.maven.plugin>
@@ -58,7 +58,7 @@
             <artifactId>resteasy-reactive</artifactId>
             <version>${quarkus-resteasy.version}</version>
             <scope>provided</scope>
-        </dependency>        
+        </dependency>
         <dependency><!-- required by 'system-stubs-junit4' -->
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>


### PR DESCRIPTION
## Motivation
Keycloak 26.0.0 was released on October 4th and we're looking into upgrading our Keycloak Environments including any plugins/providers.

## What
Update Keycloak Dependency to 26.0.0

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 

