### PR TITLE
aerogear-214 : Fixes IndexOutOfBounds issue

### DIFF
--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
@@ -65,21 +65,23 @@ class ResourceExtractor {
     static String getURI(UriInfo uriInfo) {
         if (URI_METRICS_ENABLED) {
             List<String> matchedURIs = uriInfo.getMatchedURIs();
-            StringBuilder sb = new StringBuilder();
+            if (!matchedURIs.isEmpty()) {
+                StringBuilder sb = new StringBuilder();
 
-            if (URI_METRICS_FILTER != null && URI_METRICS_FILTER.length() != 0) {
-                String[] filter = URI_METRICS_FILTER.split(",");
+                if (URI_METRICS_FILTER != null && URI_METRICS_FILTER.length() != 0) {
+                    String[] filter = URI_METRICS_FILTER.split(",");
 
-                for (int i = 0; i < filter.length; i++) {
-                    if (matchedURIs.get(0).contains(filter[i])) {
+                    for (int i = 0; i < filter.length; i++) {
+                        if (matchedURIs.get(0).contains(filter[i])) {
 
-                        sb = getURIDetailed(sb, matchedURIs);
+                            sb = getURIDetailed(sb, matchedURIs);
+                        }
                     }
+                } else {
+                    sb = getURIDetailed(sb, matchedURIs);
                 }
-            } else {
-                sb = getURIDetailed(sb, matchedURIs);
+                return sb.toString();
             }
-            return sb.toString();
         }
         return "";
     }


### PR DESCRIPTION
Fixes IndexOutOfBoundsException with keycloak 25 and keycloak-metrics-spi 6.0.0

## Motivation
https://github.com/aerogear/keycloak-metrics-spi/issues/214

## What
Adding a check that `matchedURIs` is not an empty list to [ResourceExtractor.getURI](https://github.com/aerogear/keycloak-metrics-spi/blob/master/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java#L65)  

## Why
Currently when using version keycloak-metrics-spi-6.0.0.jar with Keycloak 25 when a call comes into a URI that doesn't have a matching resource `uriInfo.getMatchedURIs` returns an empty list see https://jakarta.ee/specifications/platform/9/apidocs/jakarta/ws/rs/core/uriinfo#getMatchedURIs--

## How
Adding a check to ensure that `get(0)` is not called on the empty list

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Make sure that URI_METRICS_ENABLED is set to true
2. Navigate to a URL that should be a 404 in keycloak like /thisdoesnotexist
3. Should no longer see the Internal Server Error page and the IndexOutOfBounds exception in the logs

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 


 

