### PR TITLE
feat: Monitoring for Specific Use Cases

### DIFF
--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/PrometheusExporter.java
@@ -157,39 +157,39 @@ public final class PrometheusExporter {
             responseTotal = Counter.build()
             .name("keycloak_response")
             .help("Total number of responses")
-            .labelNames("code", "method", "resource", "uri")
+            .labelNames("code", "method", "resource", "service_code", "uri")
             .register();
 
             responseErrors = Counter.build()
             .name("keycloak_response_errors")
             .help("Total number of error responses")
-            .labelNames("code", "method", "resource", "uri")
+            .labelNames("code", "method", "resource", "service_code", "uri")
             .register();
 
             requestDuration = Histogram.build()
             .name("keycloak_request_duration")
             .help("Request duration")
             .buckets(50, 100, 250, 500, 1000, 2000, 10000, 30000)
-            .labelNames("code", "method", "resource", "uri")
+            .labelNames("code", "method", "resource", "service_code", "uri")
             .register();
         } else {
             responseTotal = Counter.build()
             .name("keycloak_response")
             .help("Total number of responses")
-            .labelNames("code", "method", "resource")
+            .labelNames("code", "method", "resource", "service_code")
             .register();
 
             responseErrors = Counter.build()
             .name("keycloak_response_errors")
             .help("Total number of error responses")
-            .labelNames("code", "method", "resource")
+            .labelNames("code", "method", "resource", "service_code")
             .register();
 
             requestDuration = Histogram.build()
             .name("keycloak_request_duration")
             .help("Request duration")
             .buckets(50, 100, 250, 500, 1000, 2000, 10000, 30000)
-            .labelNames("code", "method", "resource")
+            .labelNames("code", "method", "resource", "service_code")
             .register();
         }
 
@@ -404,8 +404,8 @@ public final class PrometheusExporter {
      * @param amt    The duration in milliseconds
      * @param method HTTP method of the request
      */
-    public void recordRequestDuration(int code, double amt, String method, String resource, String uri) {
-        requestDuration.labels(Integer.toString(code), method, resource, uri).observe(amt);
+    public void recordRequestDuration(int code, double amt, String method, String resource, String serviceCode, String uri) {
+        requestDuration.labels(Integer.toString(code), method, resource, serviceCode, uri).observe(amt);
         pushAsync();
     }
 
@@ -415,8 +415,8 @@ public final class PrometheusExporter {
      * @param amt    The duration in milliseconds
      * @param method HTTP method of the request
      */
-    public void recordRequestDuration(int code, double amt, String method, String resource) {
-        requestDuration.labels(Integer.toString(code), method, resource).observe(amt);
+    public void recordRequestDuration(int code, double amt, String method, String resource, String serviceCode) {
+        requestDuration.labels(Integer.toString(code), method, resource, serviceCode).observe(amt);
         pushAsync();
     }
 
@@ -426,8 +426,8 @@ public final class PrometheusExporter {
      * @param code   The returned http status code
      * @param method The request method used
      */
-    public void recordResponseTotal(int code, String method, String resource, String uri) {
-        responseTotal.labels(Integer.toString(code), method, resource, uri).inc();
+    public void recordResponseTotal(int code, String method, String resource, String serviceCode, String uri) {
+        responseTotal.labels(Integer.toString(code), method, resource, serviceCode, uri).inc();
         pushAsync();
     }
 
@@ -437,8 +437,8 @@ public final class PrometheusExporter {
      * @param code   The returned http status code
      * @param method The request method used
      */
-    public void recordResponseTotal(int code, String method, String resource) {
-        responseTotal.labels(Integer.toString(code), method, resource).inc();
+    public void recordResponseTotal(int code, String method, String resource, String serviceCode) {
+        responseTotal.labels(Integer.toString(code), method, resource, serviceCode).inc();
         pushAsync();
     }
 
@@ -448,8 +448,8 @@ public final class PrometheusExporter {
      * @param code   The returned http status code
      * @param method The request method used
      */
-    public void recordResponseError(int code, String method, String resource, String uri) {
-        responseErrors.labels(Integer.toString(code), method, resource, uri).inc();
+    public void recordResponseError(int code, String method, String resource, String serviceCode, String uri) {
+        responseErrors.labels(Integer.toString(code), method, resource, serviceCode, uri).inc();
         pushAsync();
     }
 
@@ -459,8 +459,8 @@ public final class PrometheusExporter {
      * @param code   The returned http status code
      * @param method The request method used
      */
-    public void recordResponseError(int code, String method, String resource) {
-        responseErrors.labels(Integer.toString(code), method, resource).inc();
+    public void recordResponseError(int code, String method, String resource, String serviceCode) {
+        responseErrors.labels(Integer.toString(code), method, resource, serviceCode).inc();
         pushAsync();
     }
 

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/ResourceExtractor.java
@@ -4,6 +4,8 @@ import jakarta.ws.rs.core.UriInfo;
 import org.jboss.logging.Logger;
 
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 class ResourceExtractor {
 
@@ -52,6 +54,18 @@ class ResourceExtractor {
                 sb.append(",");
                 sb.append(matchedURIs.get(matchedURIs.size() - 2));
                 return sb.toString();
+            }
+        }
+        return "";
+    }
+
+    static String getServiceCode(UriInfo uriInfo) {
+        if (!IS_RESOURCE_SCRAPING_DISABLED) {
+            Map<String, String> urlMappings = URLMapping.getData();
+            for (String key : urlMappings.keySet()) {
+                if (Pattern.compile(key).matcher(uriInfo.getPath()).matches()) {
+                    return urlMappings.get(key);
+                }
             }
         }
         return "";

--- a/src/main/java/org/jboss/aerogear/keycloak/metrics/URLMapping.java
+++ b/src/main/java/org/jboss/aerogear/keycloak/metrics/URLMapping.java
@@ -1,0 +1,18 @@
+package org.jboss.aerogear.keycloak.metrics;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class URLMapping {
+
+    public static Map<String, String> getData() {
+
+        Map<String, String> urlMappings = new HashMap<>();
+        urlMappings.put("/realms/.{1,255}/login-actions/authenticate", "authenticate");
+        urlMappings.put("/realms/.{1,255}/login-actions/registration", "registration");
+        urlMappings.put("/realms/.{1,255}/account/password", "password");
+        urlMappings.put("/realms/.{1,255}/protocol/openid-connect/logout", "logout");
+
+        return urlMappings;
+    }
+}


### PR DESCRIPTION
## Motivation
Current IAM metrics lack detail to distinguish between specific actions like login, registration, logout, and password change.
Relates to: https://github.com/aerogear/keycloak-metrics-spi/issues/227

## What
Add a `service_code`  to IAM metrics for better differentiation of use cases.

## Why
To enable detailed monitoring and analysis of IAM activities which current metrics do not support.

## How
Extend metrics schema to include service_code tagging each IAM action.

## Verification Steps

1. Clone the repository and build the SPI module.
2. Run Keycloak with the SPI deployed.
3. Perform IAM actions such as user login, registration, logout, and password change.
4. Check the emitted metrics by querying the `/metrics` path.
5. Verify that metrics similar to the following appear:
`keycloak_response_total{code="200", method="GET", resource="realms,realms/{realm}/login-actions", service_code="authenticate"} 2.0`
- This indicates that the monitoring with the new `service_code` is successful.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

No additional notes.
 

