### PR TITLE
fix(dashboard): add support for custom datasource

### DIFF
--- a/grafana/10441.json
+++ b/grafana/10441.json
@@ -42,7 +42,7 @@
         "type": "dashboard"
       },
       {
-        "datasource": "$Datasource",
+        "datasource": "${Datasource}",
         "enable": true,
         "iconColor": "red",
         "name": "New annotation"
@@ -60,7 +60,7 @@
   "panels": [
     {
       "CustomPanel": {
-        "datasource": "$Datasource",
+        "datasource": "${Datasource}",
         "description": "Memory currently being used by Keycloak.",
         "fieldConfig": {
           "defaults": {
@@ -129,7 +129,7 @@
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "editable": false,
       "error": false,
@@ -188,7 +188,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "editorMode": "code",
           "expr": "sum(jvm_memory_bytes_used{kubernetes_pod_name=\"$instance\", area=\"heap\"})*100/sum(jvm_memory_bytes_max{kubernetes_pod_name=\"$instance\", area=\"heap\"})",
@@ -203,7 +203,7 @@
     },
     {
       "CustomPanel": {
-        "datasource": "$Datasource",
+        "datasource": "${Datasource}",
         "description": "Memory currently being used by Keycloak.",
         "fieldConfig": {
           "defaults": {
@@ -272,7 +272,7 @@
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "editable": false,
       "error": false,
@@ -331,7 +331,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "editorMode": "code",
           "expr": "sum(jvm_memory_bytes_used{kubernetes_pod_name=\"$instance\", area=\"nonheap\"})*100/sum(jvm_memory_bytes_max{kubernetes_pod_name=\"$instance\", area=\"nonheap\"})",
@@ -347,7 +347,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -431,7 +431,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "editorMode": "code",
           "expr": "sum(jvm_memory_bytes_max{kubernetes_pod_name=\"$instance\"})",
@@ -444,7 +444,7 @@
         },
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "editorMode": "code",
           "expr": "sum(jvm_memory_bytes_committed{kubernetes_pod_name=\"$instance\"})",
@@ -458,7 +458,7 @@
         },
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "editorMode": "code",
           "expr": "sum(jvm_memory_bytes_used{kubernetes_pod_name=\"$instance\"})",
@@ -477,7 +477,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -527,7 +527,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -547,7 +547,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -597,7 +597,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -617,7 +617,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -667,7 +667,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -687,7 +687,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -737,7 +737,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -757,7 +757,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -838,7 +838,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -858,7 +858,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -942,7 +942,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -964,7 +964,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1070,7 +1070,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (error) (increase(keycloak_failed_login_attempts_total{realm=\"$realm\"}[30m]))",
@@ -1088,7 +1088,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1172,7 +1172,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (client_id)(increase(keycloak_logins_total{realm=\"$realm\"}[30m]))",
@@ -1190,7 +1190,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1272,7 +1272,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (realm) (increase(keycloak_registrations_errors_total{realm=\"$realm\"} [30m]))",
@@ -1285,7 +1285,7 @@
         },
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (error) (increase(keycloak_registrations_errors_total{realm=\"$realm\"} [30m]))",
@@ -1301,7 +1301,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1385,7 +1385,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1407,7 +1407,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1492,7 +1492,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "editorMode": "builder",
           "expr": "sum by (error) (increase(keycloak_failed_login_attempts_total{realm=\"$realm\",client_id=\"$ClientId\"}[30m]))",
@@ -1510,7 +1510,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1594,7 +1594,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (client_id)(increase(keycloak_registrations_total{realm=\"$realm\"}[30m]))",
@@ -1607,7 +1607,7 @@
         },
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (realm)(increase(keycloak_registrations_total{realm=\"$realm\"} [30m]))",
@@ -1623,7 +1623,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1708,7 +1708,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (error) (increase(keycloak_registrations_errors_total{realm=\"$realm\",client_id=\"$ClientId\"}[30m]))",
@@ -1735,7 +1735,7 @@
       "dataFormat": "tsbuckets",
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -1811,7 +1811,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1846,7 +1846,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -1907,7 +1907,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1938,7 +1938,7 @@
       "dataFormat": "tsbuckets",
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -2014,7 +2014,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2049,7 +2049,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -2110,7 +2110,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2141,7 +2141,7 @@
       "dataFormat": "tsbuckets",
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -2217,7 +2217,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2252,7 +2252,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -2313,7 +2313,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2344,7 +2344,7 @@
       "dataFormat": "tsbuckets",
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -2420,7 +2420,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2455,7 +2455,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$Datasource"
+        "uid": "${Datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -2516,7 +2516,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$Datasource"
+            "uid": "${Datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2569,7 +2569,7 @@
           "value": ""
         },
         "datasource": {
-          "uid": "$Datasource"
+          "uid": "${Datasource}"
         },
         "definition": "label_values(keycloak_logins_total,kubernetes_pod_name)",
         "hide": 0,
@@ -2602,7 +2602,7 @@
           "value": "OmCloud"
         },
         "datasource": {
-          "uid": "$Datasource"
+          "uid": "${Datasource}"
         },
         "definition": "label_values(keycloak_logins_total,realm)",
         "hide": 0,
@@ -2638,7 +2638,7 @@
           ]
         },
         "datasource": {
-          "uid": "$Datasource"
+          "uid": "${Datasource}"
         },
         "definition": "label_values(keycloak_logins_total{realm=\"$realm\"},client_id)",
         "hide": 0,
@@ -2695,6 +2695,6 @@
   "timezone": "",
   "title": "Keycloak Metrics Dashboard",
   "uid": "keycloak-dashboard",
-  "version": 7,
+  "version": 8,
   "weekStart": ""
 }


### PR DESCRIPTION
## Motivation
I was unable to use a metrics datasource that is not prometheus.

## What
Add support for custom datasources in the dashboard.

## Why
I was unable to use a metrics datasource that is not prometheus.

## How
Added curly braces around the variable.

## Verification Steps

1. Deploy dashboard
```
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard
metadata:
  name: keycloak
spec:
  folder: Keycloak
  instanceSelector:
    matchLabels:
      dashboards: grafana
  datasources:
    - inputName: Datasource
      datasourceName: victoriametrics
  url: https://raw.githubusercontent.com/kevincali/keycloak-metrics-spi/refs/heads/master/grafana/10441.json
```
2. Be happy that the dashboard shows data :D

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

This was only tested with `victoriametrics` as a datasource. 
I assume this won't break anything with `prometheus`.

